### PR TITLE
Add Google repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
     }
 }
 project.ext {


### PR DESCRIPTION
Hello,

This patch fixes the following error:
```
Could not resolve all files for configuration ':plugins:ews-android-api:lintClassPath'.
> Could not find com.android.tools.lint:lint-gradle:26.1.2.
  Searched in the following locations:
      https://jcenter.bintray.com/com/android/tools/lint/lint-gradle/26.1.2/lint-gradle-26.1.2.pom
      https://jcenter.bintray.com/com/android/tools/lint/lint-gradle/26.1.2/lint-gradle-26.1.2.jar
  Required by:
      project :plugins:ews-android-api
```