### PR TITLE
Update gradle-wrapper.properties

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,3 +4,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionSha256Sum=7a2c66d1a78f811d5f37d14630ad21cec5e77a2a4dc61e787e2257a6341016ce


### PR DESCRIPTION
Hi,

This small PR adds the `distributionSha256Sum` property to `gradle-wrapper.properties`. It allows for verification of the downloaded Gradle distribution via SHA-256 hash sum comparison.

You can find some documentation about this security improvement [here](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:verification), and the sums for each version of gradle [here](https://services.gradle.org/distributions/).

Note that you need to update this property every time you change your version of gradle.

#1 