### PR TITLE
Fix Gradle repositories order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
         google()
+        jcenter()
     }
 
     dependencies {
@@ -17,8 +13,8 @@ buildscript {
 }
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 project.ext {


### PR DESCRIPTION
Hello,

When trying to build 1.6.0 for F-Droid (https://github.com/cmeng-git/atalk-android/issues/1), I am getting this error:
```
Could not resolve all files for configuration ':aTalk:fdroidDebugCompileClasspath'.
> Could not find support-vector-drawable.aar (com.android.support:support-vector-drawable:27.1.1).
  Searched in the following locations:
      https://jcenter.bintray.com/com/android/support/support-vector-drawable/27.1.1/support-vector-drawable-27.1.1.aar
```

This is a kown issue: with some versions of the build tools, the `google()` repository needs to come first.
So this patch fixes this error.