### PR TITLE
Reorder maven repos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
         google()
+        jcenter()
     }
 
     dependencies {
@@ -17,8 +13,8 @@ buildscript {
 }
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 project.ext {


### PR DESCRIPTION
...and remove duplicated Google.

Else `gradle` would not find `com.android.support:support-vector-drawable:27.1.1`