### PR TITLE
When possible replace HTTP URLs with HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Features
 aTalk is an xmpp client designed for android and supports the following features:
-* Instant messaging in plain text and End-to-End encryption with [OMEMO](http://conversations.im/omemo/) or [OTR](https://otr.cypherpunks.ca/)
+* Instant messaging in plain text and End-to-End encryption with [OMEMO](https://conversations.im/omemo/) or [OTR](https://otr.cypherpunks.ca/)
 * SSL Certificate authentication, DNSSEC and DANE Security implementation for enhanced secure Connection Establishment
 * OMEMO encryption in multi-user-chat session, give users' maximum privacy and security
 * OMEMO Media File Sharing for all files including Stickers, Bitmoji and Emoji rich contents
@@ -128,7 +128,7 @@ Libraries used in this project:
 * [bouncycastle](https://github.com/bcgit/bc-java)
 * [butterknife](https://github.com/JakeWharton/butterknife)
 * [ckChangeLog](https://github.com/cketti/ckChangeLog)
-* [commons-text](http://commons.apache.org/proper/commons-text/)
+* [commons-text](https://commons.apache.org/proper/commons-text/)
 * [Dexter](https://github.com/Karumi/Dexter)
 * [FFmpeg](https://github.com/FFmpeg/FFmpeg)
 * [glide](https://github.com/bumptech/glide)
@@ -154,7 +154,7 @@ Libraries used in this project:
 * [TokenAutoComplete](https://github.com/splitwise/TokenAutoComplete)
 * [uCrop](https://github.com/Yalantis/uCrop)
 * [weupnp](https://github.com/bitletorg/weupnp)
-* [x264](http://git.videolan.org/git/x264.git)
+* [x264](https://git.videolan.org/git/x264.git)
 * [zrtp4j-light](https://github.com/jitsi/zrtp4j)
 
 Other contributors:

--- a/aTalk/jni/ffmpeg/README.md
+++ b/aTalk/jni/ffmpeg/README.md
@@ -16,17 +16,17 @@ such as audio, video, subtitles and related metadata.
 
 ## Tools
 
-* [ffmpeg](http://ffmpeg.org/ffmpeg.html) is a command line toolbox to manipulate, convert and stream multimedia content.
-* [ffplay](http://ffmpeg.org/ffplay.html) is a minimalistic multimedia player.
-* [ffprobe](http://ffmpeg.org/ffprobe.html) is a simple analysis tool to inspect multimedia content.
-* [ffserver](http://ffmpeg.org/ffserver.html) is a multimedia streaming server for live broadcasts.
+* [ffmpeg](https://ffmpeg.org/ffmpeg.html) is a command line toolbox to manipulate, convert and stream multimedia content.
+* [ffplay](https://ffmpeg.org/ffplay.html) is a minimalistic multimedia player.
+* [ffprobe](https://ffmpeg.org/ffprobe.html) is a simple analysis tool to inspect multimedia content.
+* [ffserver](https://ffmpeg.org/ffserver.html) is a multimedia streaming server for live broadcasts.
 * Additional small tools such as `aviocat`, `ismindex` and `qt-faststart`.
 
 ## Documentation
 
 The offline documentation is available in the **doc/** directory.
 
-The online documentation is available in the main [website](http://ffmpeg.org) and in the [wiki](http://trac.ffmpeg.org).
+The online documentation is available in the main [website](https://ffmpeg.org) and in the [wiki](https://trac.ffmpeg.org).
 
 ### Examples
 

--- a/aTalk/src/main/java/net/java/sip/communicator/impl/protocol/jabber/ProtocolProviderServiceJabberImpl.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/impl/protocol/jabber/ProtocolProviderServiceJabberImpl.java
@@ -228,7 +228,7 @@ public class ProtocolProviderServiceJabberImpl extends AbstractProtocolProviderS
     public static final String URN_IETF_RFC_3264 = "urn:ietf:rfc:3264";
 
     /**
-     * http://xmpp.org/extensions/xep-0092.html Software Version.
+     * https://xmpp.org/extensions/xep-0092.html Software Version.
      */
     // Used in JVB
     public static final String URN_XMPP_IQ_VERSION = "jabber:iq:version";
@@ -357,9 +357,9 @@ public class ProtocolProviderServiceJabberImpl extends AbstractProtocolProviderS
     /**
      * A set of features supported by our Jabber implementation. In general, we add new feature(s)
      * when we add new operation sets.
-     * (see xep-0030 : http://www.xmpp.org/extensions/xep-0030.html#info).
+     * (see xep-0030 : https://www.xmpp.org/extensions/xep-0030.html#info).
      * Example : to tell the world that we support jingle, we simply have to do :
-     * supportedFeatures.add("http://www.xmpp.org/extensions/xep-0166.html#ns"); Beware there is no
+     * supportedFeatures.add("https://www.xmpp.org/extensions/xep-0166.html#ns"); Beware there is no
      * canonical mapping between op set and jabber features (op set is a SC "concept"). This means
      * that one op set in SC can correspond to many jabber features. It is also possible that there
      * is no jabber feature corresponding to a SC op set or again, we can currently support some
@@ -1843,7 +1843,7 @@ public class ProtocolProviderServiceJabberImpl extends AbstractProtocolProviderS
 
         /* This is the "main" feature to advertise when a client support muc. We have to
          * add some features for specific functionality we support in muc.
-         * see http://www.xmpp.org/extensions/xep-0045.html
+         * see https://www.xmpp.org/extensions/xep-0045.html
          * The http://jabber.org/protocol/muc feature is already included in smack.
          */
         // XEP-0045: Multi-User Chat

--- a/aTalk/src/main/java/net/java/sip/communicator/impl/protocol/jabber/ServerStoredContactListJabberImpl.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/impl/protocol/jabber/ServerStoredContactListJabberImpl.java
@@ -463,7 +463,7 @@ public class ServerStoredContactListJabberImpl
         }
         cursor.close();
 
-        // @see <a href="http://xmpp.org/extensions/xep-0172.html">XEP-0172: User Nickname</a>
+        // @see <a href="https://xmpp.org/extensions/xep-0172.html">XEP-0172: User Nickname</a>
         StanzaListener stanzaInterceptor = new StanzaListener()
         {
             @Override

--- a/aTalk/src/main/java/net/java/sip/communicator/plugin/otr/ScOtrEngine.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/plugin/otr/ScOtrEngine.java
@@ -32,8 +32,8 @@ public interface ScOtrEngine {
 	 * @param contact The contact with whom we want to start the Smp negotiation
 	 * @param question The question that is asked during the Smp negotiation
 	 * @param secret The secret answer for the question.
-	 * @See <a href="http://en.wikipedia.org/wiki/Socialist_Millionaire_Problem"
-	 * >http://en.wikipedia.org/wiki/Socialist_Millionaire_Problem</a>
+	 * @See <a href="https://en.wikipedia.org/wiki/Socialist_Millionaire_Problem"
+	 * >https://en.wikipedia.org/wiki/Socialist_Millionaire_Problem</a>
 	 */
 	public abstract void initSmp(OtrContact contact, String question, String secret);
 
@@ -46,8 +46,8 @@ public interface ScOtrEngine {
 	 * response
 	 * @param question The question that is asked during the Smp negotiation.
 	 * @param secret The secret answer for the question.
-	 * @See <a href="http://en.wikipedia.org/wiki/Socialist_Millionaire_Problem"
-	 * >http://en.wikipedia.org/wiki/Socialist_Millionaire_Problem</a>
+	 * @See <a href="https://en.wikipedia.org/wiki/Socialist_Millionaire_Problem"
+	 * >https://en.wikipedia.org/wiki/Socialist_Millionaire_Problem</a>
 	 */
 	public abstract void respondSmp(OtrContact contact, InstanceTag receiverTag, String question, String secret);
 
@@ -56,8 +56,8 @@ public interface ScOtrEngine {
 	 *
 	 * @param contact The contact with whom we want to abort the
 	 * Smp negotiation process.
-	 * @See <a href="http://en.wikipedia.org/wiki/Socialist_Millionaire_Problem"
-	 * >http://en.wikipedia.org/wiki/Socialist_Millionaire_Problem</a>
+	 * @See <a href="https://en.wikipedia.org/wiki/Socialist_Millionaire_Problem"
+	 * >https://en.wikipedia.org/wiki/Socialist_Millionaire_Problem</a>
 	 */
 	public abstract void abortSmp(OtrContact contact);
 

--- a/aTalk/src/main/java/net/java/sip/communicator/plugin/otr/ScOtrEngineImpl.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/plugin/otr/ScOtrEngineImpl.java
@@ -680,7 +680,7 @@ public class ScOtrEngineImpl implements ScOtrEngine, ChatLinkClickedListener, Se
             // QueryMessages it calls OtrEngineHost.getFallbackMessage() which is currently the
             // only host method that uses HTML so we can simply check if the injected message
             // contains the string that getFallbackMessage() returns.
-            String otrHtmlFallbackMessage = "<a href=\"http://en.wikipedia.org/wiki/Off-the-Record_Messaging\">";
+            String otrHtmlFallbackMessage = "<a href=\"https://en.wikipedia.org/wiki/Off-the-Record_Messaging\">";
             int mimeType = messageText.contains(otrHtmlFallbackMessage)
                     ? IMessage.ENCODE_HTML : IMessage.ENCODE_PLAIN;
             IMessage message = imOpSet.createMessage(messageText, mimeType, null);

--- a/aTalk/src/main/java/net/java/sip/communicator/service/protocol/media/CallPeerMediaHandler.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/service/protocol/media/CallPeerMediaHandler.java
@@ -1587,7 +1587,7 @@ public abstract class CallPeerMediaHandler<T extends MediaAwareCallPeer<?, ?, ?>
      * identifier (shared between the local audio and video streams towards the <tt>CallPeer</tt>)
      * and an identifier for the particular stream, separated by a space.
      *
-     * {@see http://tools.ietf.org/html/draft-ietf-mmusic-msid}
+     * {@see https://tools.ietf.org/html/draft-ietf-mmusic-msid}
      *
      * @param mediaType the media type of the stream for which to return the value for 'msid'
      * @return the value to use for the 'msid' source-specific SDP media attribute (RFC5576) for

--- a/aTalk/src/main/java/net/java/sip/communicator/service/protocol/media/ConferenceInfoDocument.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/service/protocol/media/ConferenceInfoDocument.java
@@ -23,7 +23,7 @@ import timber.log.Timber;
  * A class that represents a Conference Information XML document as defined in RFC4575. It wraps
  * around a DOM <tt>Document</tt> providing convenience functions.
  *
- * {@link "http://tools.ietf.org/html/rfc4575"}
+ * {@link "https://tools.ietf.org/html/rfc4575"}
  *
  * @author Boris Grozev
  * @author Sebastien Vincent

--- a/aTalk/src/main/java/net/java/sip/communicator/util/Entities.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/util/Entities.java
@@ -27,10 +27,10 @@ import java.util.*;
  * @author <a href="mailto:ggregory@seagullsw.com">Gary Gregory</a>
  * @version $Id$
  * @see <a href="http://hotwired.lycos.com/webmonkey/reference/special_characters/">ISO Entities</a>
- * @see <a href="http://www.w3.org/TR/REC-html32#latin1">HTML 3.2 Character Entities for ISO Latin-1</a>
- * @see <a href="http://www.w3.org/TR/REC-html40/sgml/entities.html">HTML 4.0 Character entity references</a>
- * @see <a href="http://www.w3.org/TR/html401/charset.html#h-5.3">HTML 4.01 Character References</a>
- * @see <a href="http://www.w3.org/TR/html401/charset.html#code-position">HTML 4.01 Code positions</a>
+ * @see <a href="https://www.w3.org/TR/REC-html32#latin1">HTML 3.2 Character Entities for ISO Latin-1</a>
+ * @see <a href="https://www.w3.org/TR/REC-html40/sgml/entities.html">HTML 4.0 Character entity references</a>
+ * @see <a href="https://www.w3.org/TR/html401/charset.html#h-5.3">HTML 4.01 Character References</a>
+ * @see <a href="https://www.w3.org/TR/html401/charset.html#code-position">HTML 4.01 Code positions</a>
  * @since 2.0
  */
 
@@ -145,7 +145,7 @@ class Entities
             {"yuml", "255"}, // ? - lowercase y, umlaut
     };
 
-    // http://www.w3.org/TR/REC-html40/sgml/entities.html package scoped for testing
+    // https://www.w3.org/TR/REC-html40/sgml/entities.html package scoped for testing
     static final String[][] HTML40_ARRAY = {
             // <!-- Latin Extended-B -->
             {"fnof", "402"}, // latin small f with hook = function= florin, U+0192 ISOtech -->

--- a/aTalk/src/main/java/org/atalk/android/gui/About.java
+++ b/aTalk/src/main/java/org/atalk/android/gui/About.java
@@ -49,7 +49,7 @@ public class About extends Activity implements OnClickListener, View.OnLongClick
             new String[]{"bouncycastle", "https://github.com/bcgit/bc-java"},
             new String[]{"butterknife", "https://github.com/JakeWharton/butterknife"},
             new String[]{"ckChangeLog", "https://github.com/cketti/ckChangeLog"},
-            new String[]{"commons-lang", "http://commons.apache.org/proper/commons-lang/"},
+            new String[]{"commons-lang", "https://commons.apache.org/proper/commons-lang/"},
             new String[]{"Dexter", "https://github.com/Karumi/Dexter"},
             new String[]{"dhcp4java", "https://github.com/ggrandes-clones/dhcp4java"},
             new String[]{"FFmpeg", "https://github.com/FFmpeg/FFmpeg"},
@@ -77,7 +77,7 @@ public class About extends Activity implements OnClickListener, View.OnLongClick
             new String[]{"TokenAutoComplete", "https://github.com/splitwise/TokenAutoComplete"},
             new String[]{"uCrop", "https://github.com/Yalantis/uCrop"},
             new String[]{"weupnp", "https://github.com/bitletorg/weupnp"},
-            new String[]{"x264", "http://git.videolan.org/git/x264.git"},
+            new String[]{"x264", "https://git.videolan.org/git/x264.git"},
             new String[]{"zrtp4j-light", "https://github.com/jitsi/zrtp4j"},
     };
 

--- a/aTalk/src/main/java/org/atalk/android/gui/call/telephony/Address.java
+++ b/aTalk/src/main/java/org/atalk/android/gui/call/telephony/Address.java
@@ -269,7 +269,7 @@ public class Address implements Serializable
 
     /**
      * Quote a string, if necessary, based upon the definition of an "atom," as defined by RFC2822
-     * (http://tools.ietf.org/html/rfc2822#section-3.2.4). Strings that consist purely of atoms are
+     * (https://tools.ietf.org/html/rfc2822#section-3.2.4). Strings that consist purely of atoms are
      * left unquoted; anything else is returned as a quoted string.
      *
      * @param text String to quote.

--- a/aTalk/src/main/java/org/atalk/impl/neomedia/codec/audio/opus/JNIEncoder.java
+++ b/aTalk/src/main/java/org/atalk/impl/neomedia/codec/audio/opus/JNIEncoder.java
@@ -462,7 +462,7 @@ public class JNIEncoder extends AbstractCodec2
 
         /*
          * TODO Use the default value for maxaveragebitrate as defined at
-         * http://tools.ietf.org/html/draft-spittka-payload-rtp-opus-02#section-6.1
+         * https://tools.ietf.org/html/draft-spittka-payload-rtp-opus-02#section-6.1
          */
         int maxaveragebitrate = -1;
 

--- a/aTalk/src/main/java/org/atalk/impl/neomedia/codec/audio/silk/SortFLP.java
+++ b/aTalk/src/main/java/org/atalk/impl/neomedia/codec/audio/silk/SortFLP.java
@@ -9,7 +9,7 @@ package org.atalk.impl.neomedia.codec.audio.silk;
  * Insertion sort (fast for already almost sorted arrays): Best case: O(n) for an already sorted
  * array Worst case: O(n^2) for an inversely sorted array
  *
- * To be implemented: Shell short: http://en.wikipedia.org/wiki/Shell_sort
+ * To be implemented: Shell short: https://en.wikipedia.org/wiki/Shell_sort
  *
  * @author Jing Dai
  * @author Dingxin Xu

--- a/aTalk/src/main/java/org/atalk/impl/neomedia/codec/video/vp8/DePacketizer.java
+++ b/aTalk/src/main/java/org/atalk/impl/neomedia/codec/video/vp8/DePacketizer.java
@@ -23,7 +23,7 @@ import timber.log.Timber;
 
 /**
  * A depacketizer from VP8.
- * See {@link "http://tools.ietf.org/html/draft-ietf-payload-vp8-11"}
+ * See {@link "https://tools.ietf.org/html/draft-ietf-payload-vp8-11"}
  *
  * @author Boris Grozev
  * @author George Politis
@@ -349,7 +349,7 @@ public class DePacketizer extends AbstractCodec2
 
     /**
      * A class that represents the VP8 Payload Descriptor structure defined
-     * in {@link "http://tools.ietf.org/html/draft-ietf-payload-vp8-10"}
+     * in {@link "https://tools.ietf.org/html/draft-ietf-payload-vp8-10"}
      */
     public static class VP8PayloadDescriptor
     {
@@ -712,7 +712,7 @@ public class DePacketizer extends AbstractCodec2
 
     /**
      * A class that represents the VP8 Payload Header structure defined
-     * in {@link "http://tools.ietf.org/html/draft-ietf-payload-vp8-10"}
+     * in {@link "https://tools.ietf.org/html/draft-ietf-payload-vp8-10"}
      */
     public static class VP8PayloadHeader
     {

--- a/aTalk/src/main/java/org/atalk/impl/neomedia/codec/video/vp8/Packetizer.java
+++ b/aTalk/src/main/java/org/atalk/impl/neomedia/codec/video/vp8/Packetizer.java
@@ -17,7 +17,7 @@ import timber.log.Timber;
 
 /**
  * Packetizes VP8 encoded frames in accord with
- * {@link "http://tools.ietf.org/html/draft-ietf-payload-vp8-07"}
+ * {@link "https://tools.ietf.org/html/draft-ietf-payload-vp8-07"}
  * <p>
  * Uses the simplest possible scheme, only splitting large packets. Extended
  * bits are never added, and PartID is always set to 0. The only bit that

--- a/aTalk/src/main/java/org/atalk/impl/neomedia/jmfext/media/protocol/rtpdumpfile/RtpdumpFileReader.java
+++ b/aTalk/src/main/java/org/atalk/impl/neomedia/jmfext/media/protocol/rtpdumpfile/RtpdumpFileReader.java
@@ -22,7 +22,7 @@ import java.io.*;
  * This class represent a rtpdump file and provide an API to get the payload of the rtp packet it
  * contains.
  * 
- * rtpdump format : - http://www.cs.columbia.edu/irt/software/rtptools/ -
+ * rtpdump format : - https://www.cs.columbia.edu/irt/software/rtptools/ -
  * https://gist.github.com/Haerezis/18e3ffc2d69c86f8463f#file-rtpdump_file_format (backup gist)
  * 
  * 

--- a/aTalk/src/main/java/org/atalk/impl/neomedia/recording/WebmDataSink.java
+++ b/aTalk/src/main/java/org/atalk/impl/neomedia/recording/WebmDataSink.java
@@ -472,7 +472,7 @@ public class WebmDataSink implements DataSink, BufferTransferHandler
      * @param offset the offset in <tt>buf</tt> where the VP8 compressed frame starts.
      * @return the value of the <tt>show_frame</tt> field from the "uncompressed data chunk" in the
      * VP8 compressed frame contained in <tt>buf</tt> at offset <tt>offset</tt>.
-     * @{link http://tools.ietf.org/html/draft-ietf-payload-vp8-11} is used.
+     * @{link https://tools.ietf.org/html/draft-ietf-payload-vp8-11} is used.
      */
     private boolean isShowFrame(byte[] buf, int offset)
     {

--- a/aTalk/src/main/java/org/atalk/impl/neomedia/transform/AbsSendTimeEngine.java
+++ b/aTalk/src/main/java/org/atalk/impl/neomedia/transform/AbsSendTimeEngine.java
@@ -21,7 +21,7 @@ import org.atalk.util.*;
  * Implements a <tt>TransformEngine</tt> which replaces the timestamps in abs-send-time RTP
  * extensions with timestamps generated locally.
  *
- * See http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
+ * See https://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
  *
  * @author Boris Grozev
  * @author Eng Chong Meng
@@ -92,7 +92,7 @@ public class AbsSendTimeEngine extends SinglePacketTransformerAdapter
     /**
      * Sets the 3 bytes at offset <tt>off</tt> in <tt>buf</tt> to the value of
      * {@link System#nanoTime()} converted to the fixed point (6.18) format specified in
-     * {@link "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"}.
+     * {@link "https://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"}.
      *
      * @param buf the buffer where to write the timestamp.
      * @param off the offset at which to write the timestamp.

--- a/aTalk/src/main/java/org/atalk/service/neomedia/RTPExtension.java
+++ b/aTalk/src/main/java/org/atalk/service/neomedia/RTPExtension.java
@@ -32,7 +32,7 @@ public class RTPExtension
 
 	/**
 	 * The URN identifying the abs-send-time RTP extension. Defined at
-	 * {@link "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"}
+	 * {@link "https://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"}
 	 */
 	public static final String ABS_SEND_TIME_URN
 			= "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time";

--- a/aTalk/src/main/java/org/atalk/util/TimeUtils.java
+++ b/aTalk/src/main/java/org/atalk/util/TimeUtils.java
@@ -133,7 +133,7 @@ public class TimeUtils
 
     /**
      * Converts the given timestamp in NTP Timestamp Format into NTP Short
-     * Format (see {@link "http://tools.ietf.org/html/rfc5905#section-6"}).
+     * Format (see {@link "https://tools.ietf.org/html/rfc5905#section-6"}).
      *
      * @param ntpTime the timestamp to convert.
      * @return the NTP Short Format timestamp, represented as a long.
@@ -145,7 +145,7 @@ public class TimeUtils
 
     /**
      * Converts a timestamp in NTP Short Format (Q16.16, see
-     * {@link "http://tools.ietf.org/html/rfc5905#section-6"}) into
+     * {@link "https://tools.ietf.org/html/rfc5905#section-6"}) into
      * milliseconds.
      *
      * @param ntpShortTime the timestamp in NTP Short Format to convert.
@@ -158,7 +158,7 @@ public class TimeUtils
 
     /**
      * Constructs a {@code long} representation of a timestamp in NTP Timestamp
-     * Format (see {@link "http://tools.ietf.org/html/rfc5905#section-6"}).
+     * Format (see {@link "https://tools.ietf.org/html/rfc5905#section-6"}).
      *
      * @param msw The most significant word (32bits) represented as a long.
      * @param lsw The least significant word (32bits) represented as a long.

--- a/aTalk/src/main/java/org/atalk/util/xml/DOMElementWriter.java
+++ b/aTalk/src/main/java/org/atalk/util/xml/DOMElementWriter.java
@@ -38,12 +38,12 @@ public class DOMElementWriter
 
 	/**
 	 * Decodes an XML (element) name according to
-	 * http://www.w3.org/TR/xml/#NT-Name.
+	 * https://www.w3.org/TR/xml/#NT-Name.
 	 *
 	 * @param name
 	 * 		the XML (element) name to be decoded
 	 * @return a <tt>String</tt> which represents <tt>name</tt> decoded
-	 * according to http://www.w3.org/TR/xml/#NT-Name
+	 * according to https://www.w3.org/TR/xml/#NT-Name
 	 */
 	public static String decodeName(String name)
 	{
@@ -100,7 +100,7 @@ public class DOMElementWriter
 
 	/**
 	 * Encodes a specific <tt>String</tt> so that it is a valid XML (element)
-	 * name according to http://www.w3.org/TR/xml/#NT-Name.
+	 * name according to https://www.w3.org/TR/xml/#NT-Name.
 	 *
 	 * @param value
 	 * 		the <tt>String</tt> to be encoded so that it is a valid XML name
@@ -156,7 +156,7 @@ public class DOMElementWriter
 
 	/**
 	 * Determines whether a specific characters is a <tt>NameChar</tt> as
-	 * defined by http://www.w3.org/TR/xml/#NT-Name.
+	 * defined by https://www.w3.org/TR/xml/#NT-Name.
 	 *
 	 * @param c
 	 * 		the character which is to be determines whether it is a
@@ -188,7 +188,7 @@ public class DOMElementWriter
 
 	/**
 	 * Determines whether a specific characters is a <tt>NameStartChar</tt> as
-	 * defined by http://www.w3.org/TR/xml/#NT-Name.
+	 * defined by https://www.w3.org/TR/xml/#NT-Name.
 	 *
 	 * @param c
 	 * 		the character to be determined whether it is a
@@ -446,10 +446,8 @@ public class DOMElementWriter
 	 * <tt>&amp;#x5d;&amp;#x5d;&amp;gt;</tt>.</p>
 	 * <p>
 	 * <p>See XML 1.0 2.2 <a
-	 * href="http://www.w3.org/TR/1998/REC-xml-19980210#charsets">http://www
-	 * .w3.org/TR/1998/REC-xml-19980210#charsets</a> and
-	 * 2.7 <a href="http://www.w3.org/TR/1998/REC-xml-19980210#sec-cdata-sect">http://www
-	 * .w3.org/TR/1998/REC-xml-19980210#sec-cdata-sect</a>.</p>
+	 * href="https://www.w3.org/TR/1998/REC-xml-19980210#charsets">https://www.w3.org/TR/1998/REC-xml-19980210#charsets</a> and
+	 * 2.7 <a href="https://www.w3.org/TR/1998/REC-xml-19980210#sec-cdata-sect">https://www.w3.org/TR/1998/REC-xml-19980210#sec-cdata-sect</a>.</p>
 	 *
 	 * @param value
 	 * 		the value to encode
@@ -525,8 +523,8 @@ public class DOMElementWriter
 	 * Is the given character allowed inside an XML document?
 	 * <p>
 	 * <p>See XML 1.0 2.2 <a
-	 * href="http://www.w3.org/TR/1998/REC-xml-19980210#charsets">
-	 * http://www.w3.org/TR/1998/REC-xml-19980210#charsets</a>.</p>
+	 * href="https://www.w3.org/TR/1998/REC-xml-19980210#charsets">
+	 * https://www.w3.org/TR/1998/REC-xml-19980210#charsets</a>.</p>
 	 *
 	 * @param c
 	 * 		the character whose nature we'd like to determine.

--- a/aTalk/src/main/java/org/atalk/util/xml/XMLUtils.java
+++ b/aTalk/src/main/java/org/atalk/util/xml/XMLUtils.java
@@ -41,8 +41,8 @@ public class XMLUtils
     /**
      * The string identifying the <tt>DocumentBuilderFactory</tt>feature which controls whether
      * inclusion of external general entities is allowed. See
-     * {@link "http://xerces.apache.org/xerces-j/features.html#external-general-entities"} and
-     * {@link "http://xerces.apache.org/xerces2-j/features.html#external-general-entities"}
+     * {@link "https://xerces.apache.org/xerces-j/features.html#external-general-entities"} and
+     * {@link "https://xerces.apache.org/xerces2-j/features.html#external-general-entities"}
      */
     private static final String FEATURE_EXTERNAL_GENERAL_ENTITIES
             = "http://xml.org/sax/features/external-general-entities";
@@ -50,8 +50,8 @@ public class XMLUtils
     /**
      * The string identifying the <tt>DocumentBuilderFactory</tt>feature which controls whether
      * inclusion of external parameter entities is allowed. See
-     * {@link "http://xerces.apache.org/xerces-j/features.html#external-parameter-entities"} and
-     * {@link "http://xerces.apache.org/xerces2-j/features.html#external-parameter-entities"}
+     * {@link "https://xerces.apache.org/xerces-j/features.html#external-parameter-entities"} and
+     * {@link "https://xerces.apache.org/xerces2-j/features.html#external-parameter-entities"}
      */
     private static final String FEATURE_EXTERNAL_PARAMETER_ENTITIES
             = "http://xml.org/sax/features/external-parameter-entities";
@@ -59,7 +59,7 @@ public class XMLUtils
     /**
      * The string identifying the <tt>DocumentBuilderFactory</tt>feature which controls whether
      * DOCTYPE declaration is allowed. See
-     * {@link "http://xerces.apache.org/xerces2-j/features.html#disallow-doctype-decl"}
+     * {@link "https://xerces.apache.org/xerces2-j/features.html#disallow-doctype-decl"}
      */
     private static final String FEATURE_DISSALLOW_DOCTYPE
             = "http://apache.org/xml/features/disallow-doctype-decl";

--- a/aTalk/src/main/java/org/jivesoftware/smack/packet/Stanza.java
+++ b/aTalk/src/main/java/org/jivesoftware/smack/packet/Stanza.java
@@ -46,7 +46,7 @@ import org.jxmpp.jid.Jid;
  *
  * @author Matt Tucker
  * @author Florian Schmaus
- * @see <a href="http://xmpp.org/rfcs/rfc6120.html#stanzas">RFC 6120 § 8. XML Stanzas</a>
+ * @see <a href="https://xmpp.org/rfcs/rfc6120.html#stanzas">RFC 6120 § 8. XML Stanzas</a>
  */
 public abstract class Stanza implements TopLevelStreamElement {
 

--- a/aTalk/src/main/java/org/jivesoftware/smack/sasl/SASLMechanism.java
+++ b/aTalk/src/main/java/org/jivesoftware/smack/sasl/SASLMechanism.java
@@ -355,7 +355,7 @@ public abstract class SASLMechanism implements Comparable<SASLMechanism> {
      *
      * @param string the String to sasl prep.
      * @return the given String SASL preped
-     * @see <a href="http://tools.ietf.org/html/rfc4013">RFC 4013 - SASLprep: Stringprep Profile for User Names and Passwords</a>
+     * @see <a href="https://tools.ietf.org/html/rfc4013">RFC 4013 - SASLprep: Stringprep Profile for User Names and Passwords</a>
      */
     protected static String saslPrep(String string) {
         return Normalizer.normalize(string, Form.NFKC);

--- a/aTalk/src/main/java/org/jivesoftware/smack/sasl/packet/SaslNonza.java
+++ b/aTalk/src/main/java/org/jivesoftware/smack/sasl/packet/SaslNonza.java
@@ -182,7 +182,7 @@ public interface SaslNonza extends Nonza {
 
     /**
      * A SASL failure stream element, also called "SASL Error".
-     * @see <a href="http://xmpp.org/rfcs/rfc6120.html#sasl-errors">RFC 6120 6.5 SASL Errors</a>
+     * @see <a href="https://xmpp.org/rfcs/rfc6120.html#sasl-errors">RFC 6120 6.5 SASL Errors</a>
      */
     class SASLFailure extends AbstractError implements SaslNonza {
         public static final String ELEMENT = "failure";

--- a/aTalk/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
+++ b/aTalk/src/main/java/org/jivesoftware/smack/tcp/XMPPTCPConnection.java
@@ -1567,7 +1567,7 @@ public class XMPPTCPConnection extends AbstractXMPPConnection {
     /**
      * Send a unconditional Stream Management acknowledgment to the server.
      * <p>
-     * See <a href="http://xmpp.org/extensions/xep-0198.html#acking">XEP-198: Stream Management § 4. Acks</a>:
+     * See <a href="https://xmpp.org/extensions/xep-0198.html#acking">XEP-198: Stream Management § 4. Acks</a>:
      * "Either party MAY send an &lt;a/&gt; element at any time (e.g., after it has received a certain number of stanzas,
      * or after a certain period of time), even if it has not received an &lt;r/&gt; element from the other party."
      * </p>

--- a/aTalk/src/main/java/org/jivesoftware/smackx/avatar/vcardavatar/provider/VCardTempXUpdateProvider.java
+++ b/aTalk/src/main/java/org/jivesoftware/smackx/avatar/vcardavatar/provider/VCardTempXUpdateProvider.java
@@ -21,10 +21,10 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with BEEM.  If not, see <http://www.gnu.org/licenses/>.
+    along with BEEM.  If not, see <https://www.gnu.org/licenses/>.
 
     Please send bug reports with examples or suggestions to
-    contact@beem-project.com or http://dev.beem-project.com/
+    contact@beem-project.com or https://dev.beem-project.com/
 
     Epitech, hereby disclaims all copyright interest in the program "Beem"
     written by Frederic-Charles Barthelery,

--- a/aTalk/src/main/java/org/jivesoftware/smackx/bytestreams/ibb/InBandBytestreamManager.java
+++ b/aTalk/src/main/java/org/jivesoftware/smackx/bytestreams/ibb/InBandBytestreamManager.java
@@ -46,7 +46,7 @@ import org.jxmpp.jid.Jid;
 
 /**
  * The InBandBytestreamManager class handles establishing In-Band Bytestreams as specified in the <a
- * href="http://xmpp.org/extensions/xep-0047.html">XEP-0047</a>.
+ * href="https://xmpp.org/extensions/xep-0047.html">XEP-0047</a>.
  * <p>
  * The In-Band Bytestreams (IBB) enables two entities to establish a virtual bytestream over which
  * they can exchange Base64-encoded chunks of data over XMPP itself. It is the fall-back mechanism
@@ -56,7 +56,7 @@ import org.jxmpp.jid.Jid;
  * send data packets or message stanzas. If IQ stanzas are used every data stanza is acknowledged by
  * the receiver. This is the recommended way to avoid possible rate-limiting penalties. Message
  * stanzas are not acknowledged because most XMPP server implementation don't support stanza
- * flow-control method like <a href="http://xmpp.org/extensions/xep-0079.html">Advanced Message
+ * flow-control method like <a href="https://xmpp.org/extensions/xep-0079.html">Advanced Message
  * Processing</a>. To set the stanza that should be used invoke {@link #setStanza(StanzaType)}.
  * <p>
  * To establish an In-Band Bytestream invoke the {@link #establishSession(Jid)} method. This will
@@ -74,7 +74,7 @@ import org.jxmpp.jid.Jid;
  * <p>
  * Note that the registered {@link InBandBytestreamListener} will NOT be notified on incoming
  * In-Band bytestream requests sent in the context of <a
- * href="http://xmpp.org/extensions/xep-0096.html">XEP-0096</a> file transfer. (See
+ * href="https://xmpp.org/extensions/xep-0096.html">XEP-0096</a> file transfer. (See
  * {@link FileTransferManager})
  * <p>
  * If no {@link InBandBytestreamListener}s are registered, all incoming In-Band bytestream requests
@@ -228,7 +228,7 @@ public final class InBandBytestreamManager extends Manager implements Bytestream
      * <p>
      * Note that the registered {@link InBandBytestreamListener} will NOT be notified on incoming
      * Socks5 bytestream requests sent in the context of <a
-     * href="http://xmpp.org/extensions/xep-0096.html">XEP-0096</a> file transfer. (See
+     * href="https://xmpp.org/extensions/xep-0096.html">XEP-0096</a> file transfer. (See
      * {@link FileTransferManager})
      *
      * @param listener the listener to register
@@ -261,7 +261,7 @@ public final class InBandBytestreamManager extends Manager implements Bytestream
      * <p>
      * Note that the registered {@link InBandBytestreamListener} will NOT be notified on incoming
      * Socks5 bytestream requests sent in the context of <a
-     * href="http://xmpp.org/extensions/xep-0096.html">XEP-0096</a> file transfer. (See
+     * href="https://xmpp.org/extensions/xep-0096.html">XEP-0096</a> file transfer. (See
      * {@link FileTransferManager})
      *
      * @param listener the listener to register
@@ -314,7 +314,7 @@ public final class InBandBytestreamManager extends Manager implements Bytestream
      * connection.
      * <p>
      * The recommended default block size is 4096 bytes. See <a
-     * href="http://xmpp.org/extensions/xep-0047.html#usage">XEP-0047</a> Section 5.
+     * href="https://xmpp.org/extensions/xep-0047.html#usage">XEP-0047</a> Section 5.
      *
      * @return the default block size
      */
@@ -327,7 +327,7 @@ public final class InBandBytestreamManager extends Manager implements Bytestream
      * connection.
      * <p>
      * The default block size must be between 1 and 65535 bytes. The recommended default block size
-     * is 4096 bytes. See <a href="http://xmpp.org/extensions/xep-0047.html#usage">XEP-0047</a>
+     * is 4096 bytes. See <a href="https://xmpp.org/extensions/xep-0047.html#usage">XEP-0047</a>
      * Section 5.
      *
      * @param defaultBlockSize the default block size to set
@@ -378,7 +378,7 @@ public final class InBandBytestreamManager extends Manager implements Bytestream
      * Returns the stanza used to send data packets.
      * <p>
      * Default is {@link StanzaType#IQ}. See <a
-     * href="http://xmpp.org/extensions/xep-0047.html#message">XEP-0047</a> Section 4.
+     * href="https://xmpp.org/extensions/xep-0047.html#message">XEP-0047</a> Section 4.
      *
      * @return the stanza used to send data packets
      */
@@ -390,7 +390,7 @@ public final class InBandBytestreamManager extends Manager implements Bytestream
      * Sets the stanza used to send data packets.
      * <p>
      * The use of {@link StanzaType#IQ} is recommended. See <a
-     * href="http://xmpp.org/extensions/xep-0047.html#message">XEP-0047</a> Section 4.
+     * href="https://xmpp.org/extensions/xep-0047.html#message">XEP-0047</a> Section 4.
      *
      * @param stanza the stanza to set
      */

--- a/aTalk/src/main/java/org/jivesoftware/smackx/chatstates/ChatStateManager.java
+++ b/aTalk/src/main/java/org/jivesoftware/smackx/chatstates/ChatStateManager.java
@@ -58,7 +58,7 @@ import org.jxmpp.jid.EntityFullJid;
 /**
  * Handles chat state for all chats on a particular XMPPConnection. This class manages both the
  * stanza extensions and the disco response necessary for compliance with
- * <a href="http://www.xmpp.org/extensions/xep-0085.html">XEP-0085</a>.
+ * <a href="https://www.xmpp.org/extensions/xep-0085.html">XEP-0085</a>.
  *
  * NOTE: {@link org.jivesoftware.smackx.chatstates.ChatStateManager#getInstance(org.jivesoftware.smack.XMPPConnection)}
  * needs to be called in order for the listeners to be registered appropriately with the connection.

--- a/aTalk/src/main/java/org/jivesoftware/smackx/filetransfer/IBBTransferNegotiator.java
+++ b/aTalk/src/main/java/org/jivesoftware/smackx/filetransfer/IBBTransferNegotiator.java
@@ -44,7 +44,7 @@ import org.jxmpp.jid.Jid;
  *
  * @author Alexander Wenckus
  * @author Henning Staib
- * @see <a href="http://xmpp.org/extensions/xep-0047.html">XEP-0047: In-Band
+ * @see <a href="https://xmpp.org/extensions/xep-0047.html">XEP-0047: In-Band
  *      Bytestreams (IBB)</a>
  */
 public class IBBTransferNegotiator extends StreamNegotiator {

--- a/aTalk/src/main/java/org/jivesoftware/smackx/httpfileupload/HttpFileUploadManager.java
+++ b/aTalk/src/main/java/org/jivesoftware/smackx/httpfileupload/HttpFileUploadManager.java
@@ -69,7 +69,7 @@ import org.jxmpp.jid.DomainBareJid;
  * @author Grigory Fedorov
  * @author Florian Schmaus
  * @author Paul Schaub
- * @see <a href="http://xmpp.org/extensions/xep-0363.html">XEP-0363: HTTP File Upload</a>
+ * @see <a href="https://xmpp.org/extensions/xep-0363.html">XEP-0363: HTTP File Upload</a>
  * @see <a href="https://xmpp.org/extensions/inbox/omemo-media-sharing.html">XEP-XXXX: OMEMO Media Sharing</a>
  */
 public final class HttpFileUploadManager extends Manager {

--- a/aTalk/src/main/res/values-es/strings.xml
+++ b/aTalk/src/main/res/values-es/strings.xml
@@ -917,10 +917,10 @@
     <string name="plugin_otr_configform_VERIFY_STATUS">Verificado: %1$s</string>
 
     <string name="plugin_otr_activator_fallbackmessage">&lt;span style="font-weight: bold;">%1$s está intentando iniciar una encriptación
-        &lt;a href="http://en.wikipedia.org/wiki/Off-the-Record_Messaging">
+        &lt;a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging">
         Conversación Off-The-Record&lt;/a>contigo. Sin embargo, el software actual no soporta
-        mensajería Off-The-Record. Para más información, véase&lt;a href="http://es.wikipedia.org/wiki/Off-the-Record_Messaging">
-        http://es.wikipedia.org/wiki/Off-the-Record_Messaging&lt;/a>&lt;/span></string>
+        mensajería Off-The-Record. Para más información, véase&lt;a href="https://es.wikipedia.org/wiki/Off-the-Record_Messaging">
+        https://es.wikipedia.org/wiki/Off-the-Record_Messaging&lt;/a>&lt;/span></string>
     <string name="plugin_otr_activator_historyoff">%1$s NO está grabando esta conversación
         Tienes que &lt;a href=\"atalk://%2$s/%3$s\">activar el historial de chat aquí&lt;/a>.</string>
     <string name="plugin_otr_activator_historyon">%1$s está grabando esta conversación en tu dispositivo.

--- a/aTalk/src/main/res/values-in/strings.xml
+++ b/aTalk/src/main/res/values-in/strings.xml
@@ -909,10 +909,10 @@
     <string name="plugin_otr_configform_REGENERATE">Menghasilkan kembali</string>
     <string name="plugin_otr_configform_VERIFY_STATUS">Diverifikasi: %1$s</string>
     <string name="plugin_otr_activator_fallbackmessage">&lt;span style="font-weight: bold;">%1$s sedang mencoba untuk menginisiasi enkripsi
-        &lt;a href="http://en.wikipedia.org/wiki/Off-the-Record_Messaging">
+        &lt;a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging">
         Percakapan Off-The-Record&lt;/a>dengan Anda. Namun perangkat lunak Anda tidak mendukung
-        Perpesanan Off-The-Record. Untuk informasi lebih lanjut, lihat&lt;a href="http://en.wikipedia.org/wiki/Off-the-Record_Messaging">
-        http://en.wikipedia.org/wiki/Off-the-Record_Messaging&lt;/a>&lt;/span></string>
+        Perpesanan Off-The-Record. Untuk informasi lebih lanjut, lihat&lt;a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging">
+        https://en.wikipedia.org/wiki/Off-the-Record_Messaging&lt;/a>&lt;/span></string>
     <string name="plugin_otr_activator_historyoff">%1$s TIDAK merekam percakapan ini. Anda dapat&lt;a href=\"atalk://%2$s/%3$s \">mengaktifkan riwayat obrolan di sini&lt;/a>.</string>
     <string name="plugin_otr_activator_historyon">%1$s merekam percakapan ini di perangkat Anda. Anda dapat&lt;a href=\"atalk://%2$s/%3$s \">mematikan riwayat obrolan di sini&lt;/a>.</string>
     <string name="plugin_otr_activator_msgfromanotherinstance">Pesan yang diterima dari instance percakapan OTR lain dengan %1$s terdeteksi.</string>

--- a/aTalk/src/main/res/values-ru/strings.xml
+++ b/aTalk/src/main/res/values-ru/strings.xml
@@ -913,10 +913,10 @@
     <string name="plugin_otr_configform_VERIFY_STATUS">Проверено: %1$s</string>
 
     <string name="plugin_otr_activator_fallbackmessage">&lt;span style="font-weight:bold;">%1$s пытается инициировать зашифрованный
-        &lt;a href="http://en.wikipedia.org/wiki/Off-the-Record_Messaging">
+        &lt;a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging">
         Отключить запись и&lt;/a>с вами. Однако ваше программное обеспечение не поддерживает
-        Off-The-Record. Для получения дополнительной информации см.&lt;a href="http://en.wikipedia.org/wiki/Off-the-Record_Messaging">
-        http://en.wikipedia.org/wiki/Off-the-Record_Messaging&lt;/a>&lt;/span></string>
+        Off-The-Record. Для получения дополнительной информации см.&lt;a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging">
+        https://en.wikipedia.org/wiki/Off-the-Record_Messaging&lt;/a>&lt;/span></string>
     <string name="plugin_otr_activator_historyoff">%1$s НЕ записывает этот разговор. Вы можете &lt;a href=\"atalk://%2$s/%3$s\">активировать историю чатов здесь &lt;/a>.</string>
     <string name="plugin_otr_activator_historyon">%1$s записывает этот разговор на вашем устройстве. Вы можете &lt;a href=\"atalk://%2$s/%3$s\">отключить историю чата здесь &lt;/a>.</string>
     <string name="plugin_otr_activator_msgfromanotherinstance">Получено сообщение из других экземпляров разговора OTR с обнаруженными %1$s.</string>

--- a/aTalk/src/main/res/values/strings.xml
+++ b/aTalk/src/main/res/values/strings.xml
@@ -969,10 +969,10 @@
     <string name="plugin_otr_configform_VERIFY_STATUS">Verified: %1$s</string>
 
     <string name="plugin_otr_activator_fallbackmessage">&lt;span style="font-weight: bold;">%1$s is trying to initiate an encrypted
-        &lt;a href="http://en.wikipedia.org/wiki/Off-the-Record_Messaging">
+        &lt;a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging">
         Off-The-Record conversation&lt;/a>with you. However your software does not support
-        Off-The-Record messaging. For more information see &lt;a href="http://en.wikipedia.org/wiki/Off-the-Record_Messaging">
-        http://en.wikipedia.org/wiki/Off-the-Record_Messaging&lt;/a>&lt;/span></string>
+        Off-The-Record messaging. For more information see &lt;a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging">
+        https://en.wikipedia.org/wiki/Off-the-Record_Messaging&lt;/a>&lt;/span></string>
     <string name="plugin_otr_activator_historyoff">%1$s is NOT recording this conversation. You can &lt;a href=\"atalk://%2$s/%3$s\">activate chat history here&lt;/a>.</string>
     <string name="plugin_otr_activator_historyon">%1$s is recording this conversation on your device. You can &lt;a href=\"atalk://%2$s/%3$s\">turn off chat history here&lt;/a>.</string>
     <string name="plugin_otr_activator_msgfromanotherinstance">Received message from another OTR conversation instances with %1$s detected.</string>

--- a/aTalk/src/resources/languages/resources.properties
+++ b/aTalk/src/resources/languages/resources.properties
@@ -5,11 +5,11 @@
 #
 # Translation files are automatically generated from:
 #
-#        http://translate.jitsi.org/
+#        https://translate.jitsi.org/
 #
 # Note to translators:
 # - do not edit the resources_xx.properties files directly. Your changes
-#   may be lost. Go to http://translate.jitsi.org/ instead.
+#   may be lost. Go to https://translate.jitsi.org/ instead.
 # - {0}, {1}... are parameters which will be replaced by the
 #   actual text at runtime, place them as you wish
 # - \ at the end of a line means that the translation is continued
@@ -987,8 +987,8 @@ plugin.branding.COPYRIGHT=<DIV><font size=3 color={0}>(c)2003-2013 Copyright \
           <a href="https://jitsi.org">https://jitsi.org</a>.\
           </font></DIV>
 plugin.branding.LICENSE=<DIV color={0}><b>Jitsi</b> is distributed under \
-        the terms of the LGPL (<a href=\"http://www.gnu.org\">\
-        http://www.gnu.org</a>).</DIV>
+        the terms of the LGPL (<a href=\"https://www.gnu.org\">\
+        https://www.gnu.org</a>).</DIV>
 
 plugin.busylampfield.PICKUP=Pickup call
 
@@ -1686,9 +1686,9 @@ plugin.otr.activator.unreadablemsgreceived={0} sent you an unreadable encrypted 
 plugin.otr.activator.requireencryption=Your message [{0}] was not sent. Private messaging is required.
 plugin.otr.activator.unreadablemsgreply=You sent {0} an unreadable encrypted message. Please end your private conversation with {1} or refresh it.
 plugin.otr.activator.fallbackmessage=<span style="font-weight: bold;">{0} is trying to initiate an encrypted \
-<a href="http://en.wikipedia.org/wiki/Off-the-Record_Messaging">Off-The-Record conversation</a> with you. However, your software does not support \
-Off-The-Record messaging. For more information see <a href="http://en.wikipedia.org/wiki/Off-the-Record_Messaging">\
-http://en.wikipedia.org/wiki/Off-the-Record_Messaging</a></span>
+<a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging">Off-The-Record conversation</a> with you. However, your software does not support \
+Off-The-Record messaging. For more information see <a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging">\
+https://en.wikipedia.org/wiki/Off-the-Record_Messaging</a></span>
 plugin.otr.activator.multipleinstancesdetected=Your buddy {0} is logged in multiple times and OTR has established multiple sessions. You can select \
 an outgoing session from the menu below. 
 plugin.otr.activator.msgfromanotherinstance={0} sent you a message that was intended for another session. If you are logged in multiple times \

--- a/art/values-xlate/strings.xml
+++ b/art/values-xlate/strings.xml
@@ -908,10 +908,10 @@
     <string name="plugin_otr_configform_VERIFY_STATUS">Verified: %1$s</string>
 
     <string name="plugin_otr_activator_fallbackmessage">&lt;span style="font-weight: bold;">%1$s is trying to initiate an encrypted
-        &lt;a href="http://en.wikipedia.org/wiki/Off-the-Record_Messaging">
+        &lt;a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging">
         Off-The-Record conversation&lt;/a>with you. However your software does not support
-        Off-The-Record messaging. For more information see &lt;a href="http://en.wikipedia.org/wiki/Off-the-Record_Messaging">
-        http://en.wikipedia.org/wiki/Off-the-Record_Messaging&lt;/a>&lt;/span></string>
+        Off-The-Record messaging. For more information see &lt;a href="https://en.wikipedia.org/wiki/Off-the-Record_Messaging">
+        https://en.wikipedia.org/wiki/Off-the-Record_Messaging&lt;/a>&lt;/span></string>
     <string name="plugin_otr_activator_historyoff">%1$s is NOT recording this conversation. You can &lt;a href=\"atalk://%2$s/%3$s\">activate chat history here&lt;/a>.</string>
     <string name="plugin_otr_activator_historyon">%1$s is recording this conversation on your device. You can &lt;a href=\"atalk://%2$s/%3$s\">turn off chat history here&lt;/a>.</string>
     <string name="plugin_otr_activator_msgfromanotherinstance">Received message from another OTR conversation instances with %1$s detected.</string>

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@
 # any settings specified in this file.
 
 # For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
+# https://www.gradle.org/docs/current/userguide/build_environment.html
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
@@ -14,7 +14,7 @@
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# https://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
 android.enableJetifier=true


### PR DESCRIPTION
Replace HTTP URLS with HTTPS for sites which support HTTPS.
Mostly in documentation strings.
