### PR TITLE
fix SDES encryption

### DIFF
--- a/aTalk/build.gradle
+++ b/aTalk/build.gradle
@@ -195,7 +195,6 @@ dependencies {
     implementation "com.google.android.material:material:${rootProject.supportLibraryVersion}"
 
     // libraries from maven repository
-    implementation 'ch.imvs:sdes4j:1.1.4'
     // for android better picker
     implementation 'com.code-troopers.betterpickers:library:3.1.0'
     implementation 'com.jakewharton:butterknife:10.1.0'

--- a/aTalk/src/main/java/ch/imvs/sdes4j/CryptoAttribute.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/CryptoAttribute.java
@@ -1,0 +1,296 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j;
+
+import java.util.*;
+
+/**
+ * Primary class for a RFC4568 Crypto Attribute.
+ * 
+ * @author Ingo Bauersachs
+ */
+public class CryptoAttribute {
+    protected int tag;
+    protected CryptoSuite cryptoSuite;
+    protected KeyParam[] keyParams;
+    protected SessionParam[] sessionParams = null;
+
+    protected CryptoAttribute(){
+    }
+
+    /**
+     * Creates an instance of a CryptoAttribute from an SDes string in the
+     * format of
+     * <tt>tag 1*WSP crypto-suite 1*WSP key-params *(1*WSP session-param)</tt>
+     * 
+     * @param attribute the encoded SDes attribute
+     * @param f factory that creates the instances for each part of the
+     *            attribute
+     * @return a parsed crypto attribute
+     */
+    public static CryptoAttribute create(String attribute, SDesFactory f) {
+        CryptoAttribute result = f.createCryptoAttribute();
+        List<String> tokens = new LinkedList<String>();
+        for (String s : attribute.split("\\s")){
+            if(s.trim().length() > 0)
+                tokens.add(s);
+        }
+
+        result.setTag(tokens.remove(0));
+        result.setCryptoSuite(tokens.remove(0), f);
+
+        if (tokens.size() < 1)
+            throw new IllegalArgumentException("There must be at least one key parameter");
+        result.setKeyParams(tokens.remove(0), f);
+
+        result.setSessionParams(tokens, f);
+        return result;
+    }
+
+    /**
+     * Creates an instance of a CryptoAttribute from a SDes attributes (tag,
+     * crypto suite, key params and session params).
+     *
+     * @param tag unparsed tag as a string. 
+     * @param cryptoSuite the crypto suite as an unparsed string.
+     * @param keyParams An unparsed string representation of the key param list
+     * (each key must be separated by a ";").
+     * @param sessionParams An unparsed string representation of the session
+     * param list (each key must be separated by a " ").
+     * @param f factory that creates the instances for each part of the
+     *            attribute
+     *
+     * @return a parsed crypto attribute
+     */
+    public static CryptoAttribute create(String tag, String cryptoSuite, String keyParams, String sessionParams, SDesFactory f) {
+        CryptoAttribute result = f.createCryptoAttribute();
+
+        result.setTag(tag);
+        result.setCryptoSuite(cryptoSuite, f);
+        result.setKeyParams(keyParams, f);
+
+        List<String> tokens = new LinkedList<String>();
+        if(sessionParams != null) {
+            for (String s : sessionParams.split("\\s")) {
+                if(s.trim().length() > 0)
+                    tokens.add(s);
+            }
+        }
+
+        result.setSessionParams(tokens, f);
+
+        return result;
+    }
+
+    /**
+     * Creates a crypto attribute from already instantiated objects.
+     * 
+     * @param tag identifier for this particular crypto attribute
+     * @param cryptoSuite identifier that describes the encryption and
+     *            authentication algorithms
+     * @param keyParams one or more sets of keying material
+     * @param sessionParams the additional key parameters
+     */
+    public CryptoAttribute(int tag, CryptoSuite cryptoSuite, KeyParam[] keyParams, SessionParam[] sessionParams) {
+        if (tag > 99999999 || tag < 0)
+            throw new IllegalArgumentException("tag can have at most 10 digits and must be non-negative");
+
+        if (cryptoSuite == null)
+            throw new IllegalArgumentException("cryptoSuite cannot be null");
+
+        if (keyParams == null || keyParams.length == 0)
+            throw new IllegalArgumentException("keyParams cannot be null or empty");
+
+        this.tag = tag;
+        this.cryptoSuite = cryptoSuite;
+        this.keyParams = keyParams;
+
+        if (sessionParams == null)
+            this.sessionParams = new SessionParam[0];
+        else
+            this.sessionParams = sessionParams;
+    }
+
+    /**
+     * Gets the identifier for this particular crypto attribute.
+     * 
+     * @return the tag
+     */
+    public int getTag() {
+        return tag;
+    }
+
+    /**
+     * Sets the tag which is used as an identifier for this particular crypto
+     * attribute. The tag MUST be unique among all crypto attributes for a given
+     * media line.
+     * 
+     * @param stringTag unparsed tag as a string. 
+     */
+    private void setTag(String stringTag) {
+        int tag = Integer.valueOf(stringTag);
+        if (tag > 99999999 || tag < 0)
+            throw new IllegalArgumentException("tag can have at most 10 digits and must be non-negative");
+        this.tag = tag;
+    }
+
+    /**
+     * Gets the identifier that describes the encryption and authentication
+     * algorithms (e.g., AES_CM_128_HMAC_SHA1_80) for the transport in question.
+     * 
+     * @return the cryptoSuite
+     */
+    public CryptoSuite getCryptoSuite() {
+        return cryptoSuite;
+    }
+
+    /**
+     * Sets the identifier that describes the encryption and authentication
+     * algorithms (e.g., AES_CM_128_HMAC_SHA1_80) for the transport in question.
+     * 
+     * @param stringCryptoSuite the crypto suite as an unparsed string.
+     * @param f factory that creates the crypto suite instance
+     */
+    private void setCryptoSuite(String stringCryptoSuite, SDesFactory f) {
+        this.cryptoSuite = f.createCryptoSuite(stringCryptoSuite);
+    }
+
+    /**
+     * Gets one or more sets of keying material for the crypto-suite in
+     * question.
+     * 
+     * @return the keyParams
+     */
+    public KeyParam[] getKeyParams() {
+        return keyParams;
+    }
+
+    /**
+     * Sets one or more sets of keying material for the crypto-suite in
+     * question.
+     * 
+     * @param stringKeyParams An unparsed string representation of the key param
+     * list (each key must be separated by a ";").
+     * @param f factory that creates the key params instances
+     */
+    private void setKeyParams(String stringKeyParams, SDesFactory f) {
+        String[] params = stringKeyParams.split(";");
+        List<KeyParam> keyParams = new LinkedList<KeyParam>();
+        for (String p : params) {
+            keyParams.add(f.createKeyParam(p));
+        }
+        this.keyParams = keyParams.toArray(f.createKeyParamArray(0));
+    }
+
+    /**
+     * Gets the additional key parameters for this particular crypto attribute.
+     * 
+     * @return the sessionParams
+     */
+    public SessionParam[] getSessionParams() {
+        return sessionParams;
+    }
+
+    /**
+     * Sets additional key parameters for this particular crypto attribute.
+     * 
+     * @param tokens List of String-Tokens where the matching items are consumed
+     *            and removed from the list
+     * @param f factory that creates the session params instances
+     */
+    private void setSessionParams(List<String> tokens, SDesFactory f) {
+        List<SessionParam> sessionParams = new LinkedList<SessionParam>();
+        while (tokens.size() > 0) {
+            sessionParams.add(f.createSessionParam(tokens.remove(0)));
+        }
+        this.sessionParams = sessionParams.toArray(f.createSessionParamArray(0));
+    }
+
+    /**
+     * Encodes this crypto attribute as a string according to the ABNF rule
+     * <tt>tag 1*WSP crypto-suite 1*WSP key-params *(1*WSP session-param)</tt>
+     * 
+     * @return Complete crypto attribute for use in the SDP.
+     */
+    public String encode() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(tag);
+        sb.append(' ');
+        sb.append(cryptoSuite.encode());
+        sb.append(' ');
+        sb.append(getKeyParamsString());
+        if (sessionParams != null && sessionParams.length > 0) {
+            sb.append(' ');
+            sb.append(getSessionParamsString());
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Returns a string representation the key parameters according to the ABNF
+     * rule key-params.
+     * 
+     * @return String representation of the list of key params separated by ";".
+     */
+    public String getKeyParamsString() {
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < keyParams.length; i++) {
+            sb.append(keyParams[i].encode());
+            if (i < keyParams.length - 1)
+                sb.append(';');
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Returns a string representation of the session parameters according to
+     * the ABNF rule session-param.
+     *
+     * @return Returns a string representation of the list of session params
+     * separated by " ", or null if there are no session params.
+     */
+    public String getSessionParamsString() {
+        if (sessionParams != null && sessionParams.length > 0) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < sessionParams.length; i++) {
+                sb.append(sessionParams[i].encode());
+                if (i < sessionParams.length - 1)
+                    sb.append(' ');
+            }
+            return sb.toString();
+        }
+        else{
+            return null;
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj != null && obj instanceof CryptoAttribute)
+        {
+            CryptoAttribute other = (CryptoAttribute)obj;
+            return encode().equals(other.encode());
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return encode().hashCode();
+    }
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/CryptoSuite.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/CryptoSuite.java
@@ -1,0 +1,31 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j;
+
+/**
+ * Interface for grammar implementations of an identifier that describes the
+ * encryption and authentication algorithms (e.g., AES_CM_128_HMAC_SHA1_80) for
+ * the transport in question
+ * 
+ * @author Ingo Bauersachs
+ */
+public interface CryptoSuite {
+    /**
+     * Encodes the information contained in this object for use in the complete
+     * crypto attribute.
+     * 
+     * @return The name of the crypto suite.
+     */
+    String encode();
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/KeyParam.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/KeyParam.java
@@ -1,0 +1,39 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j;
+
+/**
+ * The key-param provides keying material for the crypto-suite in question. It
+ * consists of a method and the actual keying information
+ * 
+ * @author Ingo Bauersachs
+ */
+public interface KeyParam {
+    /**
+     * Gets the method name that defines the type of the key information. Only
+     * one method is defined, namely, "inline", which indicates that the actual
+     * keying material is provided in the key-info field itself.
+     * 
+     * @return <code>inline</code>
+     */
+    String getKeyMethod();
+
+    /**
+     * Encodes the information contained in this object for use in the complete
+     * crypto attribute.
+     * 
+     * @return Textual representation of the key parameter.
+     */
+    String encode();
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/SDesFactory.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/SDesFactory.java
@@ -1,0 +1,77 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j;
+
+import java.util.Random;
+
+/**
+ * Interface to create instances of specific grammar 
+ * 
+ * @author Ingo Bauersachs
+ */
+public interface SDesFactory {
+    /**
+     * Creates a crypto suite instance for the grammar implementing this interface.
+     * 
+     * @param suite The suite name that defines the cryptographic parameters.
+     * @return A crypto suite instance based on the supplied suite name.
+     */
+    CryptoSuite createCryptoSuite(String suite);
+
+    /**
+     * Creates a key parameter instance for the grammar implementing this interface.
+     * 
+     * @param keyParam The textual representation of the key parameter field.
+     * @return The parsed key parameter.
+     */
+    KeyParam createKeyParam(String keyParam);
+
+    /**
+     * Utility method to create a typed array of <code>KeyParameter</code>s.
+     * 
+     * @param size The size of the array to create.
+     * @return KeyParam array of the specified size.
+     */
+    KeyParam[] createKeyParamArray(int size);
+
+    /**
+     * Creates a session parameter instance for the grammar implementing this interface.
+     * 
+     * @param sessionParam The textual representation of the session parameter.
+     * @return The parsed session parameter.
+     */
+    SessionParam createSessionParam(String sessionParam);
+
+    /**
+     * Utility method to create a typed array of <code>SessionParam</code>s.
+     * 
+     * @param size The size of the array to create.
+     * @return SessionParam array of the specified size.
+     */
+    SessionParam[] createSessionParamArray(int size);
+
+    /**
+     * Creates an empty crypto attribute for the grammar implementing this interface.
+     * 
+     * @return Empty crypto attribute to be filled by a parser.
+     */
+    CryptoAttribute createCryptoAttribute();
+
+    /**
+     * Sets the random number generator to be used for generating the SDES keys.
+     * 
+     * @param r The random number generator.
+     */
+    void setRandomGenerator(Random r);
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/SessionParam.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/SessionParam.java
@@ -1,0 +1,29 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j;
+
+/**
+ * Interface for Session parameters that are specific to a given transport.
+ * 
+ * @author Ingo Bauersachs
+ */
+public interface SessionParam {
+    /**
+     * Encodes the information contained in this object for use in the complete
+     * crypto attribute.
+     * 
+     * @return Textual representation of the session parameter.
+     */
+    String encode();
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/srtp/FecKeySessionParam.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/srtp/FecKeySessionParam.java
@@ -1,0 +1,74 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j.srtp;
+
+/**
+ * FEC_KEY signals the use of separate master key(s) for a Forward Error
+ * Correction (FEC) stream.
+ * 
+ * @author Ingo Bauersachs
+ */
+public class FecKeySessionParam extends SrtpSessionParam {
+    private SrtpKeyParam[] keyParams;
+
+    /**
+     * Creates a new instance of this class from known key parameters.
+     * @param keyParams The key parameters to use for this FEC session parameter.
+     */
+    public FecKeySessionParam(SrtpKeyParam[] keyParams) {
+        this.keyParams = keyParams;
+    }
+
+    /**
+     * Creates a new instance of this class from the textual representation of the session parameter.
+     * @param param The textual representation of the session parameter.
+     */
+    public FecKeySessionParam(String param) {
+        String[] params = param.substring("FEC_KEY=".length()).split(";");
+        this.keyParams = new SrtpKeyParam[params.length];
+        for (int i = 0; i < this.keyParams.length; i++) {
+            this.keyParams[i] = createSrtpKeyParam(params[i]);
+        }
+    }
+
+    /**
+     * Factory method to create the key parameter objects.
+     * 
+     * @param p The key parameter to parse.
+     * @return The parsed key parameter.
+     */
+    protected SrtpKeyParam createSrtpKeyParam(String p) {
+        return new SrtpKeyParam(p);
+    }
+
+    /**
+     * Gets the key parameters of this session parameter.
+     * @return The key parameters of this session parameter.
+     */
+    public SrtpKeyParam[] getKeyParams() {
+        return keyParams;
+    }
+
+    @Override
+    public String encode() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("FEC_KEY=");
+        for (int i = 0; i < keyParams.length; i++) {
+            sb.append(keyParams[i].encode());
+            if (i < keyParams.length - 1)
+                sb.append(';');
+        }
+        return sb.toString();
+    }
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/srtp/FecOrderSessionParam.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/srtp/FecOrderSessionParam.java
@@ -1,0 +1,89 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j.srtp;
+
+/**
+ * FEC_ORDER signals the use of forward error correction for the RTP packets
+ * [RFC2733]. The forward error correction values for "order" are FEC_SRTP or
+ * SRTP_FEC. FEC_SRTP signals that FEC is applied before SRTP processing by the
+ * sender of the SRTP media and after SRTP processing by the receiver of the
+ * SRTP media; FEC_SRTP is the default. SRTP_FEC is the reverse processing.
+ * 
+ * @author Ingo Bauersachs
+ */
+public class FecOrderSessionParam extends SrtpSessionParam {
+    /**
+     * FEC_SRTP signals that FEC is applied before SRTP processing by the sender
+     * of the SRTP media and after SRTP processing by the receiver of the SRTP
+     * media; FEC_SRTP is the default.
+     */
+    public final static int FEC_SRTP = 1;
+
+    /**
+     * SRTP_FEC signals that SRTP processing is performed before applying FEC by
+     * the sender of the SRTP media and after FEC processing by the receiver of
+     * the SRTP media.
+     */
+    public final static int SRTP_FEC = 2;
+
+    private int mode;
+
+    /**
+     * Creates a new instance of this class from a known order value.
+     * 
+     * @param mode {@value #FEC_SRTP} or {@value #SRTP_FEC}
+     */
+    public FecOrderSessionParam(int mode) {
+        if (mode != FEC_SRTP && mode != SRTP_FEC)
+            throw new IllegalArgumentException("mode must be one of FEC_SRTP or SRTP_FEC");
+        this.mode = mode;
+    }
+
+    /**
+     * Creates a new instance of this class from the textual representation of
+     * the session parameter.
+     * 
+     * @param param The textual representation of the session parameter.
+     */
+    public FecOrderSessionParam(String param) {
+        param = param.substring("FEC_ORDER=".length());
+        if (param.equals("FEC_SRTP"))
+            mode = FEC_SRTP;
+        else if (param.equals("SRTP_FEC"))
+            mode = SRTP_FEC;
+        else
+            throw new IllegalArgumentException("unknown value");
+    }
+
+    /**
+     * Gets the forward error correction mode.
+     * 
+     * @return {@value #SRTP_FEC} or {@value #FEC_SRTP}
+     */
+    public int getMode() {
+        return mode;
+    }
+
+    @Override
+    public String encode() {
+        switch (mode) {
+            case FEC_SRTP:
+                return "FEC_ORDER=FEC_SRTP";
+            case SRTP_FEC:
+                return "FEC_ORDER=SRTP_FEC";
+        }
+        throw new IllegalArgumentException("invalid mode");
+    }
+
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/srtp/KdrSessionParam.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/srtp/KdrSessionParam.java
@@ -1,0 +1,76 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j.srtp;
+
+/**
+ * KDR specifies the Key Derivation Rate, as described in Section 4.3.1 of
+ * [RFC3711].
+ * 
+ * The value n MUST be a decimal integer in the set {1,2,...,24}, which denotes
+ * a power of 2 from 2^1 to 2^24, inclusive; leading zeroes MUST NOT be used.
+ * The SRTP key derivation rate controls how frequently a new session key is
+ * derived from an SRTP master key(s) [RFC3711] given in the declaration. When
+ * the key derivation rate is not specified (i.e., the KDR parameter is
+ * omitted), a single initial key derivation is performed [RFC3711].
+ * 
+ * @author Ingo Bauersachs
+ */
+public class KdrSessionParam extends SrtpSessionParam {
+    private int kdr;
+
+    /**
+     * Creates a new instance of this class from a known derivation rate.
+     * 
+     * @param kdr The key derivation rate.
+     */
+    public KdrSessionParam(int kdr) {
+        if (kdr < 0 || kdr > 24)
+            throw new IllegalArgumentException("kdr must be in range 0..24 inclusive");
+        this.kdr = kdr;
+    }
+
+    /**
+     * Creates a new instance of this class from the textual representation.
+     * 
+     * @param param The textual representation of the key derivation rate parameter.
+     */
+    public KdrSessionParam(String param) {
+        kdr = Integer.valueOf(param.substring("KDR=".length()));
+        if (kdr < 0 || kdr > 24)
+            throw new IllegalArgumentException("kdr must be in range 0..24 inclusive");
+    }
+
+    /**
+     * The key derivation rate as encoded in the session parameters.
+     * 
+     * @return decimal integer in the set {1,2,...,24}
+     */
+    public int getKeyDerivationRate() {
+        return kdr;
+    }
+
+    /**
+     * The key derivation rate in its exponentiated form.
+     * 
+     * @return integer in the range from 2 to 16'777'216.
+     */
+    public int getKeyDerivationRateExpanded() {
+        return (int) Math.pow(2, kdr);
+    }
+
+    @Override
+    public String encode() {
+        return "KDR=" + String.valueOf(kdr);
+    }
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/srtp/NoAuthSessionParam.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/srtp/NoAuthSessionParam.java
@@ -1,0 +1,41 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j.srtp;
+
+/**
+ * SRTP and SRTCP packet payloads are authenticated by default. The
+ * UNAUTHENTICATED_SRTP session parameter signals that SRTP messages are not
+ * authenticated. Use of UNAUTHENTICATED_SRTP is NOT RECOMMENDED (see Security
+ * Considerations).
+ * 
+ * @author Ingo Bauersachs
+ */
+public class NoAuthSessionParam extends SrtpSessionParam {
+    private static final String UNAUTHENTICATED_SRTP = "UNAUTHENTICATED_SRTP";
+
+    @Override
+    public String encode() {
+        return UNAUTHENTICATED_SRTP;
+    }
+
+    @Override
+    public int hashCode() {
+        return UNAUTHENTICATED_SRTP.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return UNAUTHENTICATED_SRTP.equals(obj);
+    }
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/srtp/PlainSrtcpSessionParam.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/srtp/PlainSrtcpSessionParam.java
@@ -1,0 +1,42 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j.srtp;
+
+/**
+ * SRTP and SRTCP packet payloads are encrypted by default. The
+ * UNENCRYPTED_SRTCP and UNENCRYPTED_SRTP session parameters modify the default
+ * behavior of the crypto-suites with which they are used.
+ * 
+ * UNENCRYPTED_SRTCP signals that the SRTP packet payloads are not encrypted.
+ * 
+ * @author Ingo Bauersachs
+ */
+public class PlainSrtcpSessionParam extends SrtpSessionParam {
+    private static final String UNENCRYPTED_SRTCP = "UNENCRYPTED_SRTCP";
+
+    @Override
+    public String encode() {
+        return UNENCRYPTED_SRTCP;
+    }
+
+    @Override
+    public int hashCode() {
+        return UNENCRYPTED_SRTCP.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return UNENCRYPTED_SRTCP.equals(obj);
+    }
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/srtp/PlainSrtpSessionParam.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/srtp/PlainSrtpSessionParam.java
@@ -1,0 +1,42 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j.srtp;
+
+/**
+ * SRTP and SRTCP packet payloads are encrypted by default. The
+ * UNENCRYPTED_SRTCP and UNENCRYPTED_SRTP session parameters modify the default
+ * behavior of the crypto-suites with which they are used.
+ * 
+ * UNENCRYPTED_SRTP signals that the SRTP packet payloads are not encrypted.
+ * 
+ * @author Ingo Bauersachs
+ */
+public class PlainSrtpSessionParam extends SrtpSessionParam {
+    private static final String UNENCRYPTED_SRTP = "UNENCRYPTED_SRTP";
+
+    @Override
+    public String encode() {
+        return UNENCRYPTED_SRTP;
+    }
+
+    @Override
+    public int hashCode() {
+        return UNENCRYPTED_SRTP.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return UNENCRYPTED_SRTP.equals(obj);
+    }
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/srtp/SrtpCryptoAttribute.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/srtp/SrtpCryptoAttribute.java
@@ -1,0 +1,68 @@
+package ch.imvs.sdes4j.srtp;
+
+import ch.imvs.sdes4j.CryptoAttribute;
+
+/**
+ * Security descriptions attribute for SRTP media streams.
+ * 
+ * @author Ingo Bauersachs
+ */
+public class SrtpCryptoAttribute extends CryptoAttribute {
+    SrtpCryptoAttribute(){
+    }
+
+    /**
+     * Creates an SRTP crypto attribute from its textual representation.
+     * 
+     * @param encoded The textual representation of the attribute.
+     * @return The parsed crypto data.
+     */
+    public static SrtpCryptoAttribute create(String encoded){
+        return (SrtpCryptoAttribute)CryptoAttribute.create(encoded, new SrtpSDesFactory());
+    }
+
+    /**
+     * Creates an instance of a SrtpCryptoAttribute from SDES attributes (tag,
+     * crypto suite, key params and session params).
+     *
+     * @param tag unparsed tag as a string. 
+     * @param cryptoSuite the crypto suite as an unparsed string.
+     * @param keyParams An unparsed string representation of the key param list
+     * (each key must be separated by a ";").
+     * @param sessionParams An unparsed string representation of the session
+     * param list (each key must be separated by a " ").
+     *
+     * @return a parsed SRTP crypto attribute.
+     */
+    public static SrtpCryptoAttribute create(String tag, String cryptoSuite, String keyParams, String sessionParams){
+        return (SrtpCryptoAttribute) CryptoAttribute.create(tag, cryptoSuite, keyParams, sessionParams, new SrtpSDesFactory());
+    }
+
+    /**
+     * Creates a crypto attribute from already instantiated objects.
+     * 
+     * @param tag identifier for this particular crypto attribute
+     * @param cryptoSuite identifier that describes the encryption and
+     *            authentication algorithms
+     * @param keyParams one or more sets of keying material
+     * @param sessionParams the additional key parameters
+     */
+    public SrtpCryptoAttribute(int tag, SrtpCryptoSuite cryptoSuite, SrtpKeyParam[] keyParams, SrtpSessionParam[] sessionParams) {
+        super(tag, cryptoSuite, keyParams, sessionParams == null ? new SrtpSessionParam[0] : sessionParams);
+    }
+
+    @Override
+    public SrtpCryptoSuite getCryptoSuite() {
+        return (SrtpCryptoSuite) super.getCryptoSuite();
+    }
+
+    @Override
+    public SrtpKeyParam[] getKeyParams() {
+        return (SrtpKeyParam[]) super.getKeyParams();
+    }
+
+    @Override
+    public SrtpSessionParam[] getSessionParams() {
+        return (SrtpSessionParam[]) super.getSessionParams();
+    }
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/srtp/SrtpCryptoSuite.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/srtp/SrtpCryptoSuite.java
@@ -1,0 +1,247 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j.srtp;
+
+import ch.imvs.sdes4j.CryptoSuite;
+
+/**
+ * Crypto suite details for the SRTP grammar.
+ * 
+ * @author Ingo Bauersachs
+ */
+public class SrtpCryptoSuite implements CryptoSuite {
+    public static final String AES_256_CM_HMAC_SHA1_32 = "AES_256_CM_HMAC_SHA1_32";
+    public static final String AES_256_CM_HMAC_SHA1_80 = "AES_256_CM_HMAC_SHA1_80";
+    public static final String AES_192_CM_HMAC_SHA1_32 = "AES_192_CM_HMAC_SHA1_32";
+    public static final String AES_192_CM_HMAC_SHA1_80 = "AES_192_CM_HMAC_SHA1_80";
+    public static final String SEED_128_GCM_96 = "SEED_128_GCM_96";
+    public static final String SEED_128_CCM_80 = "SEED_128_CCM_80";
+    public static final String SEED_CTR_128_HMAC_SHA1_80 = "SEED_CTR_128_HMAC_SHA1_80";
+    public static final String F8_128_HMAC_SHA1_80 = "F8_128_HMAC_SHA1_80";
+    public static final String AES_CM_128_HMAC_SHA1_32 = "AES_CM_128_HMAC_SHA1_32";
+    public static final String AES_CM_128_HMAC_SHA1_80 = "AES_CM_128_HMAC_SHA1_80";
+
+    public final static int ENCRYPTION_AES128_CM = 1;
+    public final static int ENCRYPTION_AES128_F8 = 2;
+    public final static int ENCRYPTION_SEED128_CTR = 5;
+    public final static int ENCRYPTION_SEED128_CCM_80 = 6;
+    public final static int ENCRYPTION_SEED128_GCM_96 = 7;
+    public final static int ENCRYPTION_AES192_CM = 8;
+    public final static int ENCRYPTION_AES256_CM = 9;
+
+    public final static int HASH_HMAC_SHA1 = 1;
+    public final static int HASH_SEED128_CCM_80 = 3;
+    public final static int HASH_SEED128_GCM_96 = 4;
+
+    private final String suite;
+
+    private int encryptionAlgorithm;
+    private int hashAlgoritm;
+    private int encKeyLength;
+    private int saltKeyLength;
+    private int srtpAuthTagLength;
+    private int srtcpAuthTagLength;
+    private int srtpAuthKeyLength;
+    private int srtcpAuthKeyLength;
+    private long srtpLifetime;
+    private long srtcpLifetime;
+
+    public SrtpCryptoSuite(String suite) {
+        this.suite = suite;
+        // as per http://www.iana.org/assignments/sdp-security-descriptions
+        if (suite.equals(AES_CM_128_HMAC_SHA1_80)) {
+            encryptionAlgorithm = ENCRYPTION_AES128_CM;
+            hashAlgoritm = HASH_HMAC_SHA1;
+            encKeyLength = 128;
+            saltKeyLength = 112;
+            srtpAuthTagLength = 80;
+            srtcpAuthTagLength = 80;
+            srtpAuthKeyLength = 160;
+            srtcpAuthKeyLength = 160;
+            srtpLifetime = 0x1000000000000L;
+            srtcpLifetime = 0x80000000L;
+        }
+        else if (suite.equals(AES_CM_128_HMAC_SHA1_32)) {
+            encryptionAlgorithm = ENCRYPTION_AES128_CM;
+            hashAlgoritm = HASH_HMAC_SHA1;
+            encKeyLength = 128;
+            saltKeyLength = 112;
+            srtpAuthTagLength = 32;
+            srtcpAuthTagLength = 80;
+            srtpAuthKeyLength = 160;
+            srtcpAuthKeyLength = 160;
+            srtpLifetime = 0x1000000000000L;
+            srtcpLifetime = 0x80000000L;
+        }
+        else if (suite.equals(F8_128_HMAC_SHA1_80)) {
+            encryptionAlgorithm = ENCRYPTION_AES128_F8;
+            hashAlgoritm = HASH_HMAC_SHA1;
+            encKeyLength = 128;
+            saltKeyLength = 112;
+            srtpAuthTagLength = 80;
+            srtcpAuthTagLength = 80;
+            srtpAuthKeyLength = 160;
+            srtcpAuthKeyLength = 160;
+            srtpLifetime = 0x1000000000000L;
+            srtcpLifetime = 0x80000000L;
+        }
+        // FIXME all that SEED stuff is not precisely declared in RFC5669
+        else if (suite.equals(SEED_CTR_128_HMAC_SHA1_80)) {
+            encryptionAlgorithm = ENCRYPTION_SEED128_CTR;
+            hashAlgoritm = HASH_HMAC_SHA1;
+            encKeyLength = 128;
+            saltKeyLength = 128;
+            srtpAuthTagLength = 80;
+            srtcpAuthTagLength = 80;
+            srtpAuthKeyLength = -1;
+            srtcpAuthKeyLength = -1;
+            srtpLifetime = 0x1000000000000L;
+            srtcpLifetime = 0x80000000L;
+            throw new UnsupportedOperationException("SEED parameters are not known for sure");
+        }
+        else if (suite.equals(SEED_128_CCM_80)) {
+            encryptionAlgorithm = ENCRYPTION_SEED128_CCM_80;
+            hashAlgoritm = HASH_SEED128_CCM_80;
+            encKeyLength = 128;
+            saltKeyLength = 128;
+            srtpAuthTagLength = 80;
+            srtcpAuthTagLength = 80;
+            srtpAuthKeyLength = -1;
+            srtcpAuthKeyLength = -1;
+            srtpLifetime = 0x1000000000000L;
+            srtcpLifetime = 0x80000000L;
+            throw new UnsupportedOperationException("SEED parameters are not known for sure");
+        }
+        else if (suite.equals(SEED_128_GCM_96)) {
+            encryptionAlgorithm = ENCRYPTION_SEED128_GCM_96;
+            hashAlgoritm = HASH_SEED128_GCM_96;
+            encKeyLength = 128;
+            saltKeyLength = 128;
+            srtpAuthTagLength = 96;
+            srtcpAuthTagLength = 96;
+            srtpAuthKeyLength = -1;
+            srtcpAuthKeyLength = -1;
+            srtpLifetime = 0x1000000000000L;
+            srtcpLifetime = 0x80000000L;
+            throw new UnsupportedOperationException("SEED parameters are not known for sure");
+        }
+        else if (suite.equals(AES_192_CM_HMAC_SHA1_80)) {
+            encryptionAlgorithm = ENCRYPTION_AES192_CM;
+            hashAlgoritm = HASH_HMAC_SHA1;
+            encKeyLength = 192;
+            saltKeyLength = 112;
+            srtpAuthTagLength = 80;
+            srtcpAuthTagLength = 80;
+            srtpAuthKeyLength = 160;
+            srtcpAuthKeyLength = 160;
+            srtpLifetime = 0x80000000L;
+            srtcpLifetime = 0x80000000L;
+        }
+        else if (suite.equals(AES_192_CM_HMAC_SHA1_32)) {
+            encryptionAlgorithm = ENCRYPTION_AES192_CM;
+            hashAlgoritm = HASH_HMAC_SHA1;
+            encKeyLength = 192;
+            saltKeyLength = 112;
+            srtpAuthTagLength = 32;
+            srtcpAuthTagLength = 80;
+            srtpAuthKeyLength = 160;
+            srtcpAuthKeyLength = 160;
+            srtpLifetime = 0x80000000L;
+            srtcpLifetime = 0x80000000L;
+        }
+        else if (suite.equals(AES_256_CM_HMAC_SHA1_80)) {
+            encryptionAlgorithm = ENCRYPTION_AES256_CM;
+            hashAlgoritm = HASH_HMAC_SHA1;
+            encKeyLength = 256;
+            saltKeyLength = 112;
+            srtpAuthTagLength = 80;
+            srtcpAuthTagLength = 80;
+            srtpAuthKeyLength = 160;
+            srtcpAuthKeyLength = 160;
+            srtpLifetime = 0x80000000L;
+            srtcpLifetime = 0x80000000L;
+        }
+        else if (suite.equals(AES_256_CM_HMAC_SHA1_32)) {
+            encryptionAlgorithm = ENCRYPTION_AES256_CM;
+            hashAlgoritm = HASH_HMAC_SHA1;
+            encKeyLength = 256;
+            saltKeyLength = 112;
+            srtpAuthTagLength = 32;
+            srtcpAuthTagLength = 80;
+            srtpAuthKeyLength = 160;
+            srtcpAuthKeyLength = 160;
+            srtpLifetime = 0x80000000L;
+            srtcpLifetime = 0x80000000L;
+        }
+        else
+            throw new IllegalArgumentException("Unknown crypto suite");
+    }
+
+    public int getEncryptionAlgorithm() {
+        return encryptionAlgorithm;
+    }
+
+    public int getHashAlgorithm() {
+        return hashAlgoritm;
+    }
+
+    public int getEncKeyLength() {
+        return encKeyLength;
+    }
+
+    public int getSaltKeyLength() {
+        return saltKeyLength;
+    }
+
+    public int getSrtpAuthTagLength() {
+        return srtpAuthTagLength;
+    }
+
+    public int getSrtcpAuthTagLength() {
+        return srtcpAuthTagLength;
+    }
+
+    public int getSrtpAuthKeyLength() {
+        return srtpAuthKeyLength;
+    }
+
+    public int getSrtcpAuthKeyLength() {
+        return srtcpAuthKeyLength;
+    }
+
+    public long getSrtpLifetime() {
+        return srtpLifetime;
+    }
+
+    public long getSrtcpLifetime() {
+        return srtcpLifetime;
+    }
+
+    @Override
+    public String encode() {
+        return suite;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj instanceof SrtpCryptoSuite && obj != null)
+            return suite.equals(((SrtpCryptoSuite)obj).suite);
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return suite.hashCode();
+    }
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/srtp/SrtpKeyParam.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/srtp/SrtpKeyParam.java
@@ -1,0 +1,165 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j.srtp;
+
+import org2.apache.commons.codec.binary.Base64;
+import org2.apache.commons.codec.binary.StringUtils;
+
+import ch.imvs.sdes4j.KeyParam;
+
+/**
+ * SRTP security descriptions define the use of the "inline" key method. Use of
+ * any other keying method (e.g., URL) for SRTP security descriptions is for
+ * further study.
+ * 
+ * The "inline" type of key contains the keying material (master key and salt)
+ * and all policy related to that master key, including how long it can be used
+ * (lifetime) and whether it uses a master key identifier (MKI) to associate an
+ * incoming SRTP packet with a particular master key.
+ * 
+ * @author Ingo Bauersachs
+ * 
+ */
+public class SrtpKeyParam implements KeyParam {
+    /**
+     * Constant for the <code>inline</code> key method.
+     */
+    public final static String KEYMETHOD_INLINE = "inline";
+
+    private final String keyMethod = KEYMETHOD_INLINE;
+    private byte[] key;
+    private int lifetime;
+    private int mki;
+    private int mkiLength;
+
+    /**
+     * Creates a new instance of this class from known parameters.
+     * 
+     * @param keyMethod The key method for this key parameter. Only
+     *            {@value #KEYMETHOD_INLINE} is currently supported.
+     * @param key Concatenated master key and salt; MUST be a unique
+     *            cryptographically random value with respect to other master
+     *            keys in the entire SDP message (i.e., including master keys
+     *            for other streams)
+     * @param lifetime The master key lifetime (max number of SRTP or SRTCP packets
+     *            using this master key)
+     * @param mki The master key identifier in the SRTP packets.
+     * @param mkiLength Length of the MKI field in SRTP packets.
+     */
+    public SrtpKeyParam(String keyMethod, byte[] key, int lifetime, int mki, int mkiLength) {
+        if (!keyMethod.equals(KEYMETHOD_INLINE))
+            throw new IllegalArgumentException("key method must be inline");
+        if (mkiLength < 0 || mkiLength > 128)
+            throw new IllegalArgumentException("mki length must be in range 1..128 inclusive or 0 to indicate default");
+
+        this.key = key;
+        this.lifetime = lifetime;
+        this.mki = mki;
+        this.mkiLength = mkiLength;
+    }
+
+    /**
+     * Creates a new instance of this class from the textual representation.
+     * 
+     * @param keyParam The textual representation of the key parameter.
+     */
+    public SrtpKeyParam(String keyParam) {
+        if (!keyParam.startsWith(keyMethod + ":"))
+            throw new IllegalArgumentException("Unknown key method in <" + keyParam + ">");
+
+        keyParam = keyParam.substring(KEYMETHOD_INLINE.length() + 1);
+        String[] parts = keyParam.split("\\|");
+        key = Base64.decodeBase64(parts[0]);
+        if(key.length == 0)
+            throw new IllegalArgumentException("key must be present");
+
+        int partIndex = 1;
+        if (parts.length > 1 && !parts[1].contains(":")) {
+            if(parts[1].startsWith("2^"))
+                lifetime = (int)Math.pow(2, Double.valueOf(parts[1].substring(2)));
+            else
+                lifetime = Integer.valueOf(parts[1]);
+            partIndex++;
+        }
+        if (parts.length > partIndex && parts[partIndex].contains(":")) {
+            String[] mkiParts = parts[partIndex].split(":");
+            mki = Integer.valueOf(mkiParts[0]);
+            mkiLength = Integer.valueOf(mkiParts[1]);
+            if (mkiLength < 1 || mkiLength > 128)
+                throw new IllegalArgumentException("mki length must be in range 1..128 inclusive");
+        }
+    }
+
+    /**
+     * The key method for this key parameter.
+     * @return {@value #KEYMETHOD_INLINE}
+     */
+    @Override
+    public String getKeyMethod() {
+        return keyMethod;
+    }
+
+    /**
+     * Gets the concatenated master key and salt.
+     * @return the concatenated master key and salt.
+     */
+    public byte[] getKey() {
+        return key;
+    }
+
+    /**
+     * Gets the master key lifetime (max number of SRTP or SRTCP packets using
+     * this master key)
+     * 
+     * @return The master key lifetime.
+     */
+    public int getLifetime() {
+        return lifetime;
+    }
+
+    /**
+     * Gets the master key identifier in the SRTP packets.
+     * @return The master key identifier in the SRTP packets.
+     */
+    public int getMki() {
+        return mki;
+    }
+
+    /**
+     * Gets the length of the MKI field in SRTP packets
+     * @return The length of the MKI field in SRTP packets.
+     */
+    public int getMkiLength() {
+        return mkiLength;
+    }
+
+    @Override
+    public String encode() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(keyMethod);
+        sb.append(':');
+        sb.append(StringUtils.newStringUtf8(Base64.encodeBase64(key, false)));
+        if (lifetime > 0) {
+            sb.append('|');
+            sb.append(lifetime);
+        }
+        if (mkiLength > 0) {
+            sb.append('|');
+            sb.append(mki);
+            sb.append(':');
+            sb.append(mkiLength);
+        }
+        return sb.toString();
+    }
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/srtp/SrtpSDesFactory.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/srtp/SrtpSDesFactory.java
@@ -1,0 +1,110 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j.srtp;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Random;
+
+import ch.imvs.sdes4j.*;
+
+/**
+ * Factory for the SRTP grammar of RFC4568.
+ * 
+ * @author Ingo Bauersachs
+ */
+public class SrtpSDesFactory implements SDesFactory {
+    private Random r = null;
+
+    /**
+     * Creates an SRTP crypto attribute with the specified parameters, for use in an SDP.
+     * <p>
+     * If no random generator is set with {@link #setRandomGenerator(Random)} then the
+     * SHA1PRNG, or if not available, the system's default {@link SecureRandom} will be used.
+     * 
+     * @param tag decimal number used as an identifier for a particular crypto attribute
+     * @param keyAlg identifier that describes the encryption and authentication algorithms
+     * @return SRTP crypto attribute without session parameters.
+     */
+    public SrtpCryptoAttribute createCryptoAttribute(int tag, String keyAlg) {
+        return createCryptoAttribute(tag, keyAlg, null);
+    }
+
+    /**
+     * Creates an SRTP crypto attribute with the specified parameters, for use in an SDP.
+     * 
+     * @param tag decimal number used as an identifier for a particular crypto attribute
+     * @param keyAlg identifier that describes the encryption and authentication algorithms
+     * @param params Session parameters for the crypto attribute
+     * @return SRTP crypto attribute without session parameters.
+     */
+    public SrtpCryptoAttribute createCryptoAttribute(int tag, String keyAlg, SrtpSessionParam[] params) {
+        SrtpCryptoSuite suite = createCryptoSuite(keyAlg);
+        byte[] keyData = new byte[(suite.getEncKeyLength() + suite.getSaltKeyLength()) / 8];
+        getRandom().nextBytes(keyData);
+        SrtpKeyParam key = new SrtpKeyParam(
+                SrtpKeyParam.KEYMETHOD_INLINE,
+                keyData,
+                0, 0, 0
+        );
+        return new SrtpCryptoAttribute(tag, suite, new SrtpKeyParam[] { key }, params);
+    }
+    
+    private Random getRandom(){
+        if(r == null){
+            try {
+                r = SecureRandom.getInstance("SHA1PRNG");
+            }
+            catch (NoSuchAlgorithmException e) {
+                r = new SecureRandom();
+            }
+        }
+        return r;
+    }
+
+    @Override
+    public void setRandomGenerator(Random r) {
+        this.r = r;
+    }
+
+    @Override
+    public SrtpCryptoAttribute createCryptoAttribute() {
+        return new SrtpCryptoAttribute();
+    }
+
+    @Override
+    public SrtpCryptoSuite createCryptoSuite(String suite) {
+        return new SrtpCryptoSuite(suite);
+    }
+
+    @Override
+    public SrtpKeyParam createKeyParam(String keyParam) {
+        return new SrtpKeyParam(keyParam);
+    }
+
+    @Override
+    public SrtpKeyParam[] createKeyParamArray(int size) {
+        return new SrtpKeyParam[size];
+    }
+
+    @Override
+    public SrtpSessionParam createSessionParam(String sessionParam) {
+        return SrtpSessionParam.create(sessionParam);
+    }
+
+    @Override
+    public SrtpSessionParam[] createSessionParamArray(int size) {
+        return new SrtpSessionParam[size];
+    }
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/srtp/SrtpSessionParam.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/srtp/SrtpSessionParam.java
@@ -1,0 +1,51 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j.srtp;
+
+import ch.imvs.sdes4j.SessionParam;
+
+/**
+ * Base class for SRTP specific session parameters.
+ * 
+ * @author Ingo Bauersachs
+ */
+public abstract class SrtpSessionParam implements SessionParam {
+    SrtpSessionParam() {
+    }
+
+    /**
+     * Creates instances from the text based representation of SRTP session parameters. 
+     * 
+     * @param param The text based representation of a session parameter.
+     * @return The instance of a SRTP session parameter.
+     */
+    public static SrtpSessionParam create(String param) {
+        if (param.startsWith("KDR="))
+            return new KdrSessionParam(param);
+        else if (param.equals("UNENCRYPTED_SRTP"))
+            return new PlainSrtpSessionParam();
+        else if (param.equals("UNENCRYPTED_SRTCP"))
+            return new PlainSrtcpSessionParam();
+        else if (param.equals("UNAUTHENTICATED_SRTP"))
+            return new NoAuthSessionParam();
+        else if (param.startsWith("FEC_ORDER="))
+            return new FecOrderSessionParam(param);
+        else if (param.startsWith("FEC_KEY="))
+            return new FecKeySessionParam(param);
+        else if (param.startsWith("WSH="))
+            return new WshSessionParam(param);
+
+        throw new IllegalArgumentException("Unknown session parameter");
+    }
+}

--- a/aTalk/src/main/java/ch/imvs/sdes4j/srtp/WshSessionParam.java
+++ b/aTalk/src/main/java/ch/imvs/sdes4j/srtp/WshSessionParam.java
@@ -1,0 +1,64 @@
+/*
+ * SDES4J
+ * Java implementation of SDES (Security Descriptions for Media Streams,
+ * RFC 4568).
+ * 
+ * Copyright (C) 2011 FHNW
+ *   University of Applied Sciences Northwestern Switzerland (FHNW)
+ *   School of Engineering
+ *   Institute of Mobile and Distributed Systems (IMVS)
+ *   http://sdes4j.imvs.ch
+ * 
+ * Distributable under LGPL license, see terms of license at gnu.org.
+ */
+package ch.imvs.sdes4j.srtp;
+
+/**
+ * SRTP defines the SRTP-WINDOW-SIZE [RFC3711, Section 3.3.2] parameter to
+ * protect against replay attacks. The Window Size Hint (WSH) session parameter
+ * provides a hint for how big this window should be to work satisfactorily.
+ * 
+ * The minimum value is 64 [RFC3711]; however, this value may be considered too
+ * low for some applications (e.g., video).
+ * 
+ * @author Ingo Bauersachs
+ */
+public class WshSessionParam extends SrtpSessionParam {
+    private int wsh;
+
+    /**
+     * Creates a new instance of this class from an integer.
+     * 
+     * @param wsh The size of the window hint.
+     */
+    public WshSessionParam(int wsh) {
+        if (wsh < 64)
+            throw new IllegalArgumentException("Minimum size is 64");
+        this.wsh = wsh;
+    }
+
+    /**
+     * Creates a new instance of this class from the textual representation.
+     * 
+     * @param param The textual representation of the WSH parameter.
+     */
+    public WshSessionParam(String param) {
+        wsh = Integer.valueOf(param.split("=")[1]);
+        if (wsh < 64)
+            throw new IllegalArgumentException("Minimum size is 64");
+    }
+
+    /**
+     * Gets the size of the window hint.
+     * 
+     * @return the size of the window hint.
+     */
+    public int getWindowSizeHint() {
+        return wsh;
+    }
+
+    @Override
+    public String encode() {
+        return "WSH=" + wsh;
+    }
+}

--- a/aTalk/src/main/java/org2/apache/commons/codec/binary/Base64.java
+++ b/aTalk/src/main/java/org2/apache/commons/codec/binary/Base64.java
@@ -1,0 +1,785 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org2.apache.commons.codec.binary;
+
+import java.math.BigInteger;
+
+/**
+ * Provides Base64 encoding and decoding as defined by <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>.
+ *
+ * <p>
+ * This class implements section <cite>6.8. Base64 Content-Transfer-Encoding</cite> from RFC 2045 <cite>Multipurpose
+ * Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies</cite> by Freed and Borenstein.
+ * </p>
+ * <p>
+ * The class can be parameterized in the following manner with various constructors:
+ * </p>
+ * <ul>
+ * <li>URL-safe mode: Default off.</li>
+ * <li>Line length: Default 76. Line length that aren't multiples of 4 will still essentially end up being multiples of
+ * 4 in the encoded data.
+ * <li>Line separator: Default is CRLF ("\r\n")</li>
+ * </ul>
+ * <p>
+ * The URL-safe parameter is only applied to encode operations. Decoding seamlessly handles both modes.
+ * </p>
+ * <p>
+ * Since this class operates directly on byte streams, and not character streams, it is hard-coded to only
+ * encode/decode character encodings which are compatible with the lower 127 ASCII chart (ISO-8859-1, Windows-1252,
+ * UTF-8, etc).
+ * </p>
+ * <p>
+ * This class is thread-safe.
+ * </p>
+ *
+ * @see <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>
+ * @since 1.0
+ * @version $Id: Base64.java 1789158 2017-03-28 15:04:58Z sebb $
+ */
+public class Base64 extends BaseNCodec {
+
+    /**
+     * BASE32 characters are 6 bits in length.
+     * They are formed by taking a block of 3 octets to form a 24-bit string,
+     * which is converted into 4 BASE64 characters.
+     */
+    private static final int BITS_PER_ENCODED_BYTE = 6;
+    private static final int BYTES_PER_UNENCODED_BLOCK = 3;
+    private static final int BYTES_PER_ENCODED_BLOCK = 4;
+
+    /**
+     * Chunk separator per RFC 2045 section 2.1.
+     *
+     * <p>
+     * N.B. The next major release may break compatibility and make this field private.
+     * </p>
+     *
+     * @see <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045 section 2.1</a>
+     */
+    static final byte[] CHUNK_SEPARATOR = {'\r', '\n'};
+
+    /**
+     * This array is a lookup table that translates 6-bit positive integer index values into their "Base64 Alphabet"
+     * equivalents as specified in Table 1 of RFC 2045.
+     *
+     * Thanks to "commons" project in ws.apache.org for this code.
+     * http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
+     */
+    private static final byte[] STANDARD_ENCODE_TABLE = {
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+            'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+            'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
+    };
+
+    /**
+     * This is a copy of the STANDARD_ENCODE_TABLE above, but with + and /
+     * changed to - and _ to make the encoded Base64 results more URL-SAFE.
+     * This table is only used when the Base64's mode is set to URL-SAFE.
+     */
+    private static final byte[] URL_SAFE_ENCODE_TABLE = {
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+            'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+            'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_'
+    };
+
+    /**
+     * This array is a lookup table that translates Unicode characters drawn from the "Base64 Alphabet" (as specified
+     * in Table 1 of RFC 2045) into their 6-bit positive integer equivalents. Characters that are not in the Base64
+     * alphabet but fall within the bounds of the array are translated to -1.
+     *
+     * Note: '+' and '-' both decode to 62. '/' and '_' both decode to 63. This means decoder seamlessly handles both
+     * URL_SAFE and STANDARD base64. (The encoder, on the other hand, needs to know ahead of time what to emit).
+     *
+     * Thanks to "commons" project in ws.apache.org for this code.
+     * http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
+     */
+    private static final byte[] DECODE_TABLE = {
+        //   0   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 00-0f
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 10-1f
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, 62, -1, 63, // 20-2f + - /
+            52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1, // 30-3f 0-9
+            -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, // 40-4f A-O
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, 63, // 50-5f P-Z _
+            -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, // 60-6f a-o
+            41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51                      // 70-7a p-z
+    };
+
+    /**
+     * Base64 uses 6-bit fields.
+     */
+    /** Mask used to extract 6 bits, used when encoding */
+    private static final int MASK_6BITS = 0x3f;
+
+    // The static final fields above are used for the original static byte[] methods on Base64.
+    // The private member fields below are used with the new streaming approach, which requires
+    // some state be preserved between calls of encode() and decode().
+
+    /**
+     * Encode table to use: either STANDARD or URL_SAFE. Note: the DECODE_TABLE above remains static because it is able
+     * to decode both STANDARD and URL_SAFE streams, but the encodeTable must be a member variable so we can switch
+     * between the two modes.
+     */
+    private final byte[] encodeTable;
+
+    // Only one decode table currently; keep for consistency with Base32 code
+    private final byte[] decodeTable = DECODE_TABLE;
+
+    /**
+     * Line separator for encoding. Not used when decoding. Only used if lineLength &gt; 0.
+     */
+    private final byte[] lineSeparator;
+
+    /**
+     * Convenience variable to help us determine when our buffer is going to run out of room and needs resizing.
+     * <code>decodeSize = 3 + lineSeparator.length;</code>
+     */
+    private final int decodeSize;
+
+    /**
+     * Convenience variable to help us determine when our buffer is going to run out of room and needs resizing.
+     * <code>encodeSize = 4 + lineSeparator.length;</code>
+     */
+    private final int encodeSize;
+
+    /**
+     * Creates a Base64 codec used for decoding (all modes) and encoding in URL-unsafe mode.
+     * <p>
+     * When encoding the line length is 0 (no chunking), and the encoding table is STANDARD_ENCODE_TABLE.
+     * </p>
+     *
+     * <p>
+     * When decoding all variants are supported.
+     * </p>
+     */
+    public Base64() {
+        this(0);
+    }
+
+    /**
+     * Creates a Base64 codec used for decoding (all modes) and encoding in the given URL-safe mode.
+     * <p>
+     * When encoding the line length is 76, the line separator is CRLF, and the encoding table is STANDARD_ENCODE_TABLE.
+     * </p>
+     *
+     * <p>
+     * When decoding all variants are supported.
+     * </p>
+     *
+     * @param urlSafe
+     *            if <code>true</code>, URL-safe encoding is used. In most cases this should be set to
+     *            <code>false</code>.
+     * @since 1.4
+     */
+    public Base64(final boolean urlSafe) {
+        this(MIME_CHUNK_SIZE, CHUNK_SEPARATOR, urlSafe);
+    }
+
+    /**
+     * Creates a Base64 codec used for decoding (all modes) and encoding in URL-unsafe mode.
+     * <p>
+     * When encoding the line length is given in the constructor, the line separator is CRLF, and the encoding table is
+     * STANDARD_ENCODE_TABLE.
+     * </p>
+     * <p>
+     * Line lengths that aren't multiples of 4 will still essentially end up being multiples of 4 in the encoded data.
+     * </p>
+     * <p>
+     * When decoding all variants are supported.
+     * </p>
+     *
+     * @param lineLength
+     *            Each line of encoded data will be at most of the given length (rounded down to nearest multiple of
+     *            4). If lineLength &lt;= 0, then the output will not be divided into lines (chunks). Ignored when
+     *            decoding.
+     * @since 1.4
+     */
+    public Base64(final int lineLength) {
+        this(lineLength, CHUNK_SEPARATOR);
+    }
+
+    /**
+     * Creates a Base64 codec used for decoding (all modes) and encoding in URL-unsafe mode.
+     * <p>
+     * When encoding the line length and line separator are given in the constructor, and the encoding table is
+     * STANDARD_ENCODE_TABLE.
+     * </p>
+     * <p>
+     * Line lengths that aren't multiples of 4 will still essentially end up being multiples of 4 in the encoded data.
+     * </p>
+     * <p>
+     * When decoding all variants are supported.
+     * </p>
+     *
+     * @param lineLength
+     *            Each line of encoded data will be at most of the given length (rounded down to nearest multiple of
+     *            4). If lineLength &lt;= 0, then the output will not be divided into lines (chunks). Ignored when
+     *            decoding.
+     * @param lineSeparator
+     *            Each line of encoded data will end with this sequence of bytes.
+     * @throws IllegalArgumentException
+     *             Thrown when the provided lineSeparator included some base64 characters.
+     * @since 1.4
+     */
+    public Base64(final int lineLength, final byte[] lineSeparator) {
+        this(lineLength, lineSeparator, false);
+    }
+
+    /**
+     * Creates a Base64 codec used for decoding (all modes) and encoding in URL-unsafe mode.
+     * <p>
+     * When encoding the line length and line separator are given in the constructor, and the encoding table is
+     * STANDARD_ENCODE_TABLE.
+     * </p>
+     * <p>
+     * Line lengths that aren't multiples of 4 will still essentially end up being multiples of 4 in the encoded data.
+     * </p>
+     * <p>
+     * When decoding all variants are supported.
+     * </p>
+     *
+     * @param lineLength
+     *            Each line of encoded data will be at most of the given length (rounded down to nearest multiple of
+     *            4). If lineLength &lt;= 0, then the output will not be divided into lines (chunks). Ignored when
+     *            decoding.
+     * @param lineSeparator
+     *            Each line of encoded data will end with this sequence of bytes.
+     * @param urlSafe
+     *            Instead of emitting '+' and '/' we emit '-' and '_' respectively. urlSafe is only applied to encode
+     *            operations. Decoding seamlessly handles both modes.
+     *            <b>Note: no padding is added when using the URL-safe alphabet.</b>
+     * @throws IllegalArgumentException
+     *             The provided lineSeparator included some base64 characters. That's not going to work!
+     * @since 1.4
+     */
+    public Base64(final int lineLength, final byte[] lineSeparator, final boolean urlSafe) {
+        super(BYTES_PER_UNENCODED_BLOCK, BYTES_PER_ENCODED_BLOCK,
+                lineLength,
+                lineSeparator == null ? 0 : lineSeparator.length);
+        // TODO could be simplified if there is no requirement to reject invalid line sep when length <=0
+        // @see test case Base64Test.testConstructors()
+        if (lineSeparator != null) {
+            if (containsAlphabetOrPad(lineSeparator)) {
+                final String sep = StringUtils.newStringUtf8(lineSeparator);
+                throw new IllegalArgumentException("lineSeparator must not contain base64 characters: [" + sep + "]");
+            }
+            if (lineLength > 0){ // null line-sep forces no chunking rather than throwing IAE
+                this.encodeSize = BYTES_PER_ENCODED_BLOCK + lineSeparator.length;
+                this.lineSeparator = new byte[lineSeparator.length];
+                System.arraycopy(lineSeparator, 0, this.lineSeparator, 0, lineSeparator.length);
+            } else {
+                this.encodeSize = BYTES_PER_ENCODED_BLOCK;
+                this.lineSeparator = null;
+            }
+        } else {
+            this.encodeSize = BYTES_PER_ENCODED_BLOCK;
+            this.lineSeparator = null;
+        }
+        this.decodeSize = this.encodeSize - 1;
+        this.encodeTable = urlSafe ? URL_SAFE_ENCODE_TABLE : STANDARD_ENCODE_TABLE;
+    }
+
+    /**
+     * Returns our current encode mode. True if we're URL-SAFE, false otherwise.
+     *
+     * @return true if we're in URL-SAFE mode, false otherwise.
+     * @since 1.4
+     */
+    public boolean isUrlSafe() {
+        return this.encodeTable == URL_SAFE_ENCODE_TABLE;
+    }
+
+    /**
+     * <p>
+     * Encodes all of the provided data, starting at inPos, for inAvail bytes. Must be called at least twice: once with
+     * the data to encode, and once with inAvail set to "-1" to alert encoder that EOF has been reached, to flush last
+     * remaining bytes (if not multiple of 3).
+     * </p>
+     * <p><b>Note: no padding is added when encoding using the URL-safe alphabet.</b></p>
+     * <p>
+     * Thanks to "commons" project in ws.apache.org for the bitwise operations, and general approach.
+     * http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
+     * </p>
+     *
+     * @param in
+     *            byte[] array of binary data to base64 encode.
+     * @param inPos
+     *            Position to start reading data from.
+     * @param inAvail
+     *            Amount of bytes available from input for encoding.
+     * @param context
+     *            the context to be used
+     */
+    @Override
+    void encode(final byte[] in, int inPos, final int inAvail, final Context context) {
+        if (context.eof) {
+            return;
+        }
+        // inAvail < 0 is how we're informed of EOF in the underlying data we're
+        // encoding.
+        if (inAvail < 0) {
+            context.eof = true;
+            if (0 == context.modulus && lineLength == 0) {
+                return; // no leftovers to process and not using chunking
+            }
+            final byte[] buffer = ensureBufferSize(encodeSize, context);
+            final int savedPos = context.pos;
+            switch (context.modulus) { // 0-2
+                case 0 : // nothing to do here
+                    break;
+                case 1 : // 8 bits = 6 + 2
+                    // top 6 bits:
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea >> 2) & MASK_6BITS];
+                    // remaining 2:
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea << 4) & MASK_6BITS];
+                    // URL-SAFE skips the padding to further reduce size.
+                    if (encodeTable == STANDARD_ENCODE_TABLE) {
+                        buffer[context.pos++] = pad;
+                        buffer[context.pos++] = pad;
+                    }
+                    break;
+
+                case 2 : // 16 bits = 6 + 6 + 4
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea >> 10) & MASK_6BITS];
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea >> 4) & MASK_6BITS];
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea << 2) & MASK_6BITS];
+                    // URL-SAFE skips the padding to further reduce size.
+                    if (encodeTable == STANDARD_ENCODE_TABLE) {
+                        buffer[context.pos++] = pad;
+                    }
+                    break;
+                default:
+                    throw new IllegalStateException("Impossible modulus "+context.modulus);
+            }
+            context.currentLinePos += context.pos - savedPos; // keep track of current line position
+            // if currentPos == 0 we are at the start of a line, so don't add CRLF
+            if (lineLength > 0 && context.currentLinePos > 0) {
+                System.arraycopy(lineSeparator, 0, buffer, context.pos, lineSeparator.length);
+                context.pos += lineSeparator.length;
+            }
+        } else {
+            for (int i = 0; i < inAvail; i++) {
+                final byte[] buffer = ensureBufferSize(encodeSize, context);
+                context.modulus = (context.modulus+1) % BYTES_PER_UNENCODED_BLOCK;
+                int b = in[inPos++];
+                if (b < 0) {
+                    b += 256;
+                }
+                context.ibitWorkArea = (context.ibitWorkArea << 8) + b; //  BITS_PER_BYTE
+                if (0 == context.modulus) { // 3 bytes = 24 bits = 4 * 6 bits to extract
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea >> 18) & MASK_6BITS];
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea >> 12) & MASK_6BITS];
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea >> 6) & MASK_6BITS];
+                    buffer[context.pos++] = encodeTable[context.ibitWorkArea & MASK_6BITS];
+                    context.currentLinePos += BYTES_PER_ENCODED_BLOCK;
+                    if (lineLength > 0 && lineLength <= context.currentLinePos) {
+                        System.arraycopy(lineSeparator, 0, buffer, context.pos, lineSeparator.length);
+                        context.pos += lineSeparator.length;
+                        context.currentLinePos = 0;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * Decodes all of the provided data, starting at inPos, for inAvail bytes. Should be called at least twice: once
+     * with the data to decode, and once with inAvail set to "-1" to alert decoder that EOF has been reached. The "-1"
+     * call is not necessary when decoding, but it doesn't hurt, either.
+     * </p>
+     * <p>
+     * Ignores all non-base64 characters. This is how chunked (e.g. 76 character) data is handled, since CR and LF are
+     * silently ignored, but has implications for other bytes, too. This method subscribes to the garbage-in,
+     * garbage-out philosophy: it will not check the provided data for validity.
+     * </p>
+     * <p>
+     * Thanks to "commons" project in ws.apache.org for the bitwise operations, and general approach.
+     * http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
+     * </p>
+     *
+     * @param in
+     *            byte[] array of ascii data to base64 decode.
+     * @param inPos
+     *            Position to start reading data from.
+     * @param inAvail
+     *            Amount of bytes available from input for encoding.
+     * @param context
+     *            the context to be used
+     */
+    @Override
+    void decode(final byte[] in, int inPos, final int inAvail, final Context context) {
+        if (context.eof) {
+            return;
+        }
+        if (inAvail < 0) {
+            context.eof = true;
+        }
+        for (int i = 0; i < inAvail; i++) {
+            final byte[] buffer = ensureBufferSize(decodeSize, context);
+            final byte b = in[inPos++];
+            if (b == pad) {
+                // We're done.
+                context.eof = true;
+                break;
+            }
+            if (b >= 0 && b < DECODE_TABLE.length) {
+                final int result = DECODE_TABLE[b];
+                if (result >= 0) {
+                    context.modulus = (context.modulus+1) % BYTES_PER_ENCODED_BLOCK;
+                    context.ibitWorkArea = (context.ibitWorkArea << BITS_PER_ENCODED_BYTE) + result;
+                    if (context.modulus == 0) {
+                        buffer[context.pos++] = (byte) ((context.ibitWorkArea >> 16) & MASK_8BITS);
+                        buffer[context.pos++] = (byte) ((context.ibitWorkArea >> 8) & MASK_8BITS);
+                        buffer[context.pos++] = (byte) (context.ibitWorkArea & MASK_8BITS);
+                    }
+                }
+            }
+        }
+
+        // Two forms of EOF as far as base64 decoder is concerned: actual
+        // EOF (-1) and first time '=' character is encountered in stream.
+        // This approach makes the '=' padding characters completely optional.
+        if (context.eof && context.modulus != 0) {
+            final byte[] buffer = ensureBufferSize(decodeSize, context);
+
+            // We have some spare bits remaining
+            // Output all whole multiples of 8 bits and ignore the rest
+            switch (context.modulus) {
+//              case 0 : // impossible, as excluded above
+                case 1 : // 6 bits - ignore entirely
+                    // TODO not currently tested; perhaps it is impossible?
+                    break;
+                case 2 : // 12 bits = 8 + 4
+                    context.ibitWorkArea = context.ibitWorkArea >> 4; // dump the extra 4 bits
+                    buffer[context.pos++] = (byte) ((context.ibitWorkArea) & MASK_8BITS);
+                    break;
+                case 3 : // 18 bits = 8 + 8 + 2
+                    context.ibitWorkArea = context.ibitWorkArea >> 2; // dump 2 bits
+                    buffer[context.pos++] = (byte) ((context.ibitWorkArea >> 8) & MASK_8BITS);
+                    buffer[context.pos++] = (byte) ((context.ibitWorkArea) & MASK_8BITS);
+                    break;
+                default:
+                    throw new IllegalStateException("Impossible modulus "+context.modulus);
+            }
+        }
+    }
+
+    /**
+     * Tests a given byte array to see if it contains only valid characters within the Base64 alphabet. Currently the
+     * method treats whitespace as valid.
+     *
+     * @param arrayOctet
+     *            byte array to test
+     * @return <code>true</code> if all bytes are valid characters in the Base64 alphabet or if the byte array is empty;
+     *         <code>false</code>, otherwise
+     * @deprecated 1.5 Use {@link #isBase64(byte[])}, will be removed in 2.0.
+     */
+    @Deprecated
+    public static boolean isArrayByteBase64(final byte[] arrayOctet) {
+        return isBase64(arrayOctet);
+    }
+
+    /**
+     * Returns whether or not the <code>octet</code> is in the base 64 alphabet.
+     *
+     * @param octet
+     *            The value to test
+     * @return <code>true</code> if the value is defined in the the base 64 alphabet, <code>false</code> otherwise.
+     * @since 1.4
+     */
+    public static boolean isBase64(final byte octet) {
+        return octet == PAD_DEFAULT || (octet >= 0 && octet < DECODE_TABLE.length && DECODE_TABLE[octet] != -1);
+    }
+
+    /**
+     * Tests a given String to see if it contains only valid characters within the Base64 alphabet. Currently the
+     * method treats whitespace as valid.
+     *
+     * @param base64
+     *            String to test
+     * @return <code>true</code> if all characters in the String are valid characters in the Base64 alphabet or if
+     *         the String is empty; <code>false</code>, otherwise
+     *  @since 1.5
+     */
+    public static boolean isBase64(final String base64) {
+        return isBase64(StringUtils.getBytesUtf8(base64));
+    }
+
+    /**
+     * Tests a given byte array to see if it contains only valid characters within the Base64 alphabet. Currently the
+     * method treats whitespace as valid.
+     *
+     * @param arrayOctet
+     *            byte array to test
+     * @return <code>true</code> if all bytes are valid characters in the Base64 alphabet or if the byte array is empty;
+     *         <code>false</code>, otherwise
+     * @since 1.5
+     */
+    public static boolean isBase64(final byte[] arrayOctet) {
+        for (int i = 0; i < arrayOctet.length; i++) {
+            if (!isBase64(arrayOctet[i]) && !isWhiteSpace(arrayOctet[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Encodes binary data using the base64 algorithm but does not chunk the output.
+     *
+     * @param binaryData
+     *            binary data to encode
+     * @return byte[] containing Base64 characters in their UTF-8 representation.
+     */
+    public static byte[] encodeBase64(final byte[] binaryData) {
+        return encodeBase64(binaryData, false);
+    }
+
+    /**
+     * Encodes binary data using the base64 algorithm but does not chunk the output.
+     *
+     * NOTE:  We changed the behaviour of this method from multi-line chunking (commons-codec-1.4) to
+     * single-line non-chunking (commons-codec-1.5).
+     *
+     * @param binaryData
+     *            binary data to encode
+     * @return String containing Base64 characters.
+     * @since 1.4 (NOTE:  1.4 chunked the output, whereas 1.5 does not).
+     */
+    public static String encodeBase64String(final byte[] binaryData) {
+        return StringUtils.newStringUsAscii(encodeBase64(binaryData, false));
+    }
+
+    /**
+     * Encodes binary data using a URL-safe variation of the base64 algorithm but does not chunk the output. The
+     * url-safe variation emits - and _ instead of + and / characters.
+     * <b>Note: no padding is added.</b>
+     * @param binaryData
+     *            binary data to encode
+     * @return byte[] containing Base64 characters in their UTF-8 representation.
+     * @since 1.4
+     */
+    public static byte[] encodeBase64URLSafe(final byte[] binaryData) {
+        return encodeBase64(binaryData, false, true);
+    }
+
+    /**
+     * Encodes binary data using a URL-safe variation of the base64 algorithm but does not chunk the output. The
+     * url-safe variation emits - and _ instead of + and / characters.
+     * <b>Note: no padding is added.</b>
+     * @param binaryData
+     *            binary data to encode
+     * @return String containing Base64 characters
+     * @since 1.4
+     */
+    public static String encodeBase64URLSafeString(final byte[] binaryData) {
+        return StringUtils.newStringUsAscii(encodeBase64(binaryData, false, true));
+    }
+
+    /**
+     * Encodes binary data using the base64 algorithm and chunks the encoded output into 76 character blocks
+     *
+     * @param binaryData
+     *            binary data to encode
+     * @return Base64 characters chunked in 76 character blocks
+     */
+    public static byte[] encodeBase64Chunked(final byte[] binaryData) {
+        return encodeBase64(binaryData, true);
+    }
+
+    /**
+     * Encodes binary data using the base64 algorithm, optionally chunking the output into 76 character blocks.
+     *
+     * @param binaryData
+     *            Array containing binary data to encode.
+     * @param isChunked
+     *            if <code>true</code> this encoder will chunk the base64 output into 76 character blocks
+     * @return Base64-encoded data.
+     * @throws IllegalArgumentException
+     *             Thrown when the input array needs an output array bigger than {@link Integer#MAX_VALUE}
+     */
+    public static byte[] encodeBase64(final byte[] binaryData, final boolean isChunked) {
+        return encodeBase64(binaryData, isChunked, false);
+    }
+
+    /**
+     * Encodes binary data using the base64 algorithm, optionally chunking the output into 76 character blocks.
+     *
+     * @param binaryData
+     *            Array containing binary data to encode.
+     * @param isChunked
+     *            if <code>true</code> this encoder will chunk the base64 output into 76 character blocks
+     * @param urlSafe
+     *            if <code>true</code> this encoder will emit - and _ instead of the usual + and / characters.
+     *            <b>Note: no padding is added when encoding using the URL-safe alphabet.</b>
+     * @return Base64-encoded data.
+     * @throws IllegalArgumentException
+     *             Thrown when the input array needs an output array bigger than {@link Integer#MAX_VALUE}
+     * @since 1.4
+     */
+    public static byte[] encodeBase64(final byte[] binaryData, final boolean isChunked, final boolean urlSafe) {
+        return encodeBase64(binaryData, isChunked, urlSafe, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Encodes binary data using the base64 algorithm, optionally chunking the output into 76 character blocks.
+     *
+     * @param binaryData
+     *            Array containing binary data to encode.
+     * @param isChunked
+     *            if <code>true</code> this encoder will chunk the base64 output into 76 character blocks
+     * @param urlSafe
+     *            if <code>true</code> this encoder will emit - and _ instead of the usual + and / characters.
+     *            <b>Note: no padding is added when encoding using the URL-safe alphabet.</b>
+     * @param maxResultSize
+     *            The maximum result size to accept.
+     * @return Base64-encoded data.
+     * @throws IllegalArgumentException
+     *             Thrown when the input array needs an output array bigger than maxResultSize
+     * @since 1.4
+     */
+    public static byte[] encodeBase64(final byte[] binaryData, final boolean isChunked,
+                                      final boolean urlSafe, final int maxResultSize) {
+        if (binaryData == null || binaryData.length == 0) {
+            return binaryData;
+        }
+
+        // Create this so can use the super-class method
+        // Also ensures that the same roundings are performed by the ctor and the code
+        final Base64 b64 = isChunked ? new Base64(urlSafe) : new Base64(0, CHUNK_SEPARATOR, urlSafe);
+        final long len = b64.getEncodedLength(binaryData);
+        if (len > maxResultSize) {
+            throw new IllegalArgumentException("Input array too big, the output array would be bigger (" +
+                len +
+                ") than the specified maximum size of " +
+                maxResultSize);
+        }
+
+        return b64.encode(binaryData);
+    }
+
+    /**
+     * Decodes a Base64 String into octets.
+     * <p>
+     * <b>Note:</b> this method seamlessly handles data encoded in URL-safe or normal mode.
+     * </p>
+     *
+     * @param base64String
+     *            String containing Base64 data
+     * @return Array containing decoded data.
+     * @since 1.4
+     */
+    public static byte[] decodeBase64(final String base64String) {
+        return new Base64().decode(base64String);
+    }
+
+    /**
+     * Decodes Base64 data into octets.
+     * <p>
+     * <b>Note:</b> this method seamlessly handles data encoded in URL-safe or normal mode.
+     * </p>
+     *
+     * @param base64Data
+     *            Byte array containing Base64 data
+     * @return Array containing decoded data.
+     */
+    public static byte[] decodeBase64(final byte[] base64Data) {
+        return new Base64().decode(base64Data);
+    }
+
+    // Implementation of the Encoder Interface
+
+    // Implementation of integer encoding used for crypto
+    /**
+     * Decodes a byte64-encoded integer according to crypto standards such as W3C's XML-Signature.
+     *
+     * @param pArray
+     *            a byte array containing base64 character data
+     * @return A BigInteger
+     * @since 1.4
+     */
+    public static BigInteger decodeInteger(final byte[] pArray) {
+        return new BigInteger(1, decodeBase64(pArray));
+    }
+
+    /**
+     * Encodes to a byte64-encoded integer according to crypto standards such as W3C's XML-Signature.
+     *
+     * @param bigInt
+     *            a BigInteger
+     * @return A byte array containing base64 character data
+     * @throws NullPointerException
+     *             if null is passed in
+     * @since 1.4
+     */
+    public static byte[] encodeInteger(final BigInteger bigInt) {
+        if (bigInt == null) {
+            throw new NullPointerException("encodeInteger called with null parameter");
+        }
+        return encodeBase64(toIntegerBytes(bigInt), false);
+    }
+
+    /**
+     * Returns a byte-array representation of a <code>BigInteger</code> without sign bit.
+     *
+     * @param bigInt
+     *            <code>BigInteger</code> to be converted
+     * @return a byte array representation of the BigInteger parameter
+     */
+    static byte[] toIntegerBytes(final BigInteger bigInt) {
+        int bitlen = bigInt.bitLength();
+        // round bitlen
+        bitlen = ((bitlen + 7) >> 3) << 3;
+        final byte[] bigBytes = bigInt.toByteArray();
+
+        if (((bigInt.bitLength() % 8) != 0) && (((bigInt.bitLength() / 8) + 1) == (bitlen / 8))) {
+            return bigBytes;
+        }
+        // set up params for copying everything but sign bit
+        int startSrc = 0;
+        int len = bigBytes.length;
+
+        // if bigInt is exactly byte-aligned, just skip signbit in copy
+        if ((bigInt.bitLength() % 8) == 0) {
+            startSrc = 1;
+            len--;
+        }
+        final int startDst = bitlen / 8 - len; // to pad w/ nulls as per spec
+        final byte[] resizedBytes = new byte[bitlen / 8];
+        System.arraycopy(bigBytes, startSrc, resizedBytes, startDst, len);
+        return resizedBytes;
+    }
+
+    /**
+     * Returns whether or not the <code>octet</code> is in the Base64 alphabet.
+     *
+     * @param octet
+     *            The value to test
+     * @return <code>true</code> if the value is defined in the the Base64 alphabet <code>false</code> otherwise.
+     */
+    @Override
+    protected boolean isInAlphabet(final byte octet) {
+        return octet >= 0 && octet < decodeTable.length && decodeTable[octet] != -1;
+    }
+
+}

--- a/aTalk/src/main/java/org2/apache/commons/codec/binary/BaseNCodec.java
+++ b/aTalk/src/main/java/org2/apache/commons/codec/binary/BaseNCodec.java
@@ -1,0 +1,547 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org2.apache.commons.codec.binary;
+
+import java.util.Arrays;
+
+import org.apache.commons.codec.BinaryDecoder;
+import org.apache.commons.codec.BinaryEncoder;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.EncoderException;
+
+/**
+ * Abstract superclass for Base-N encoders and decoders.
+ *
+ * <p>
+ * This class is thread-safe.
+ * </p>
+ *
+ * @version $Id: BaseNCodec.java 1811344 2017-10-06 15:19:57Z ggregory $
+ */
+public abstract class BaseNCodec implements BinaryEncoder, BinaryDecoder {
+
+    /**
+     * Holds thread context so classes can be thread-safe.
+     *
+     * This class is not itself thread-safe; each thread must allocate its own copy.
+     *
+     * @since 1.7
+     */
+    static class Context {
+
+        /**
+         * Place holder for the bytes we're dealing with for our based logic.
+         * Bitwise operations store and extract the encoding or decoding from this variable.
+         */
+        int ibitWorkArea;
+
+        /**
+         * Place holder for the bytes we're dealing with for our based logic.
+         * Bitwise operations store and extract the encoding or decoding from this variable.
+         */
+        long lbitWorkArea;
+
+        /**
+         * Buffer for streaming.
+         */
+        byte[] buffer;
+
+        /**
+         * Position where next character should be written in the buffer.
+         */
+        int pos;
+
+        /**
+         * Position where next character should be read from the buffer.
+         */
+        int readPos;
+
+        /**
+         * Boolean flag to indicate the EOF has been reached. Once EOF has been reached, this object becomes useless,
+         * and must be thrown away.
+         */
+        boolean eof;
+
+        /**
+         * Variable tracks how many characters have been written to the current line. Only used when encoding. We use
+         * it to make sure each encoded line never goes beyond lineLength (if lineLength &gt; 0).
+         */
+        int currentLinePos;
+
+        /**
+         * Writes to the buffer only occur after every 3/5 reads when encoding, and every 4/8 reads when decoding. This
+         * variable helps track that.
+         */
+        int modulus;
+
+        Context() {
+        }
+
+        /**
+         * Returns a String useful for debugging (especially within a debugger.)
+         *
+         * @return a String useful for debugging.
+         */
+        @SuppressWarnings("boxing") // OK to ignore boxing here
+        @Override
+        public String toString() {
+            return String.format("%s[buffer=%s, currentLinePos=%s, eof=%s, ibitWorkArea=%s, lbitWorkArea=%s, " +
+                    "modulus=%s, pos=%s, readPos=%s]", this.getClass().getSimpleName(), Arrays.toString(buffer),
+                    currentLinePos, eof, ibitWorkArea, lbitWorkArea, modulus, pos, readPos);
+        }
+    }
+
+    /**
+     * EOF
+     *
+     * @since 1.7
+     */
+    static final int EOF = -1;
+
+    /**
+     *  MIME chunk size per RFC 2045 section 6.8.
+     *
+     * <p>
+     * The {@value} character limit does not count the trailing CRLF, but counts all other characters, including any
+     * equal signs.
+     * </p>
+     *
+     * @see <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045 section 6.8</a>
+     */
+    public static final int MIME_CHUNK_SIZE = 76;
+
+    /**
+     * PEM chunk size per RFC 1421 section 4.3.2.4.
+     *
+     * <p>
+     * The {@value} character limit does not count the trailing CRLF, but counts all other characters, including any
+     * equal signs.
+     * </p>
+     *
+     * @see <a href="http://tools.ietf.org/html/rfc1421">RFC 1421 section 4.3.2.4</a>
+     */
+    public static final int PEM_CHUNK_SIZE = 64;
+
+    private static final int DEFAULT_BUFFER_RESIZE_FACTOR = 2;
+
+    /**
+     * Defines the default buffer size - currently {@value}
+     * - must be large enough for at least one encoded block+separator
+     */
+    private static final int DEFAULT_BUFFER_SIZE = 8192;
+
+    /** Mask used to extract 8 bits, used in decoding bytes */
+    protected static final int MASK_8BITS = 0xff;
+
+    /**
+     * Byte used to pad output.
+     */
+    protected static final byte PAD_DEFAULT = '='; // Allow static access to default
+
+    /**
+     * @deprecated Use {@link #pad}. Will be removed in 2.0.
+     */
+    @Deprecated
+    protected final byte PAD = PAD_DEFAULT; // instance variable just in case it needs to vary later
+
+    protected final byte pad; // instance variable just in case it needs to vary later
+
+    /** Number of bytes in each full block of unencoded data, e.g. 4 for Base64 and 5 for Base32 */
+    private final int unencodedBlockSize;
+
+    /** Number of bytes in each full block of encoded data, e.g. 3 for Base64 and 8 for Base32 */
+    private final int encodedBlockSize;
+
+    /**
+     * Chunksize for encoding. Not used when decoding.
+     * A value of zero or less implies no chunking of the encoded data.
+     * Rounded down to nearest multiple of encodedBlockSize.
+     */
+    protected final int lineLength;
+
+    /**
+     * Size of chunk separator. Not used unless {@link #lineLength} &gt; 0.
+     */
+    private final int chunkSeparatorLength;
+
+    /**
+     * Note <code>lineLength</code> is rounded down to the nearest multiple of {@link #encodedBlockSize}
+     * If <code>chunkSeparatorLength</code> is zero, then chunking is disabled.
+     * @param unencodedBlockSize the size of an unencoded block (e.g. Base64 = 3)
+     * @param encodedBlockSize the size of an encoded block (e.g. Base64 = 4)
+     * @param lineLength if &gt; 0, use chunking with a length <code>lineLength</code>
+     * @param chunkSeparatorLength the chunk separator length, if relevant
+     */
+    protected BaseNCodec(final int unencodedBlockSize, final int encodedBlockSize,
+                         final int lineLength, final int chunkSeparatorLength) {
+        this(unencodedBlockSize, encodedBlockSize, lineLength, chunkSeparatorLength, PAD_DEFAULT);
+    }
+
+    /**
+     * Note <code>lineLength</code> is rounded down to the nearest multiple of {@link #encodedBlockSize}
+     * If <code>chunkSeparatorLength</code> is zero, then chunking is disabled.
+     * @param unencodedBlockSize the size of an unencoded block (e.g. Base64 = 3)
+     * @param encodedBlockSize the size of an encoded block (e.g. Base64 = 4)
+     * @param lineLength if &gt; 0, use chunking with a length <code>lineLength</code>
+     * @param chunkSeparatorLength the chunk separator length, if relevant
+     * @param pad byte used as padding byte.
+     */
+    protected BaseNCodec(final int unencodedBlockSize, final int encodedBlockSize,
+                         final int lineLength, final int chunkSeparatorLength, final byte pad) {
+        this.unencodedBlockSize = unencodedBlockSize;
+        this.encodedBlockSize = encodedBlockSize;
+        final boolean useChunking = lineLength > 0 && chunkSeparatorLength > 0;
+        this.lineLength = useChunking ? (lineLength / encodedBlockSize) * encodedBlockSize : 0;
+        this.chunkSeparatorLength = chunkSeparatorLength;
+
+        this.pad = pad;
+    }
+
+    /**
+     * Returns true if this object has buffered data for reading.
+     *
+     * @param context the context to be used
+     * @return true if there is data still available for reading.
+     */
+    boolean hasData(final Context context) {  // package protected for access from I/O streams
+        return context.buffer != null;
+    }
+
+    /**
+     * Returns the amount of buffered data available for reading.
+     *
+     * @param context the context to be used
+     * @return The amount of buffered data available for reading.
+     */
+    int available(final Context context) {  // package protected for access from I/O streams
+        return context.buffer != null ? context.pos - context.readPos : 0;
+    }
+
+    /**
+     * Get the default buffer size. Can be overridden.
+     *
+     * @return {@link #DEFAULT_BUFFER_SIZE}
+     */
+    protected int getDefaultBufferSize() {
+        return DEFAULT_BUFFER_SIZE;
+    }
+
+    /**
+     * Increases our buffer by the {@link #DEFAULT_BUFFER_RESIZE_FACTOR}.
+     * @param context the context to be used
+     */
+    private byte[] resizeBuffer(final Context context) {
+        if (context.buffer == null) {
+            context.buffer = new byte[getDefaultBufferSize()];
+            context.pos = 0;
+            context.readPos = 0;
+        } else {
+            final byte[] b = new byte[context.buffer.length * DEFAULT_BUFFER_RESIZE_FACTOR];
+            System.arraycopy(context.buffer, 0, b, 0, context.buffer.length);
+            context.buffer = b;
+        }
+        return context.buffer;
+    }
+
+    /**
+     * Ensure that the buffer has room for <code>size</code> bytes
+     *
+     * @param size minimum spare space required
+     * @param context the context to be used
+     * @return the buffer
+     */
+    protected byte[] ensureBufferSize(final int size, final Context context){
+        if ((context.buffer == null) || (context.buffer.length < context.pos + size)){
+            return resizeBuffer(context);
+        }
+        return context.buffer;
+    }
+
+    /**
+     * Extracts buffered data into the provided byte[] array, starting at position bPos, up to a maximum of bAvail
+     * bytes. Returns how many bytes were actually extracted.
+     * <p>
+     * Package protected for access from I/O streams.
+     *
+     * @param b
+     *            byte[] array to extract the buffered data into.
+     * @param bPos
+     *            position in byte[] array to start extraction at.
+     * @param bAvail
+     *            amount of bytes we're allowed to extract. We may extract fewer (if fewer are available).
+     * @param context
+     *            the context to be used
+     * @return The number of bytes successfully extracted into the provided byte[] array.
+     */
+    int readResults(final byte[] b, final int bPos, final int bAvail, final Context context) {
+        if (context.buffer != null) {
+            final int len = Math.min(available(context), bAvail);
+            System.arraycopy(context.buffer, context.readPos, b, bPos, len);
+            context.readPos += len;
+            if (context.readPos >= context.pos) {
+                context.buffer = null; // so hasData() will return false, and this method can return -1
+            }
+            return len;
+        }
+        return context.eof ? EOF : 0;
+    }
+
+    /**
+     * Checks if a byte value is whitespace or not.
+     * Whitespace is taken to mean: space, tab, CR, LF
+     * @param byteToCheck
+     *            the byte to check
+     * @return true if byte is whitespace, false otherwise
+     */
+    protected static boolean isWhiteSpace(final byte byteToCheck) {
+        switch (byteToCheck) {
+            case ' ' :
+            case '\n' :
+            case '\r' :
+            case '\t' :
+                return true;
+            default :
+                return false;
+        }
+    }
+
+    /**
+     * Encodes an Object using the Base-N algorithm. This method is provided in order to satisfy the requirements of
+     * the Encoder interface, and will throw an EncoderException if the supplied object is not of type byte[].
+     *
+     * @param obj
+     *            Object to encode
+     * @return An object (of type byte[]) containing the Base-N encoded data which corresponds to the byte[] supplied.
+     * @throws EncoderException
+     *             if the parameter supplied is not of type byte[]
+     */
+    @Override
+    public Object encode(final Object obj) throws EncoderException {
+        if (!(obj instanceof byte[])) {
+            throw new EncoderException("Parameter supplied to Base-N encode is not a byte[]");
+        }
+        return encode((byte[]) obj);
+    }
+
+    /**
+     * Encodes a byte[] containing binary data, into a String containing characters in the Base-N alphabet.
+     * Uses UTF8 encoding.
+     *
+     * @param pArray
+     *            a byte array containing binary data
+     * @return A String containing only Base-N character data
+     */
+    public String encodeToString(final byte[] pArray) {
+        return StringUtils.newStringUtf8(encode(pArray));
+    }
+
+    /**
+     * Encodes a byte[] containing binary data, into a String containing characters in the appropriate alphabet.
+     * Uses UTF8 encoding.
+     *
+     * @param pArray a byte array containing binary data
+     * @return String containing only character data in the appropriate alphabet.
+     * @since 1.5
+     * This is a duplicate of {@link #encodeToString(byte[])}; it was merged during refactoring.
+    */
+    public String encodeAsString(final byte[] pArray){
+        return StringUtils.newStringUtf8(encode(pArray));
+    }
+
+    /**
+     * Decodes an Object using the Base-N algorithm. This method is provided in order to satisfy the requirements of
+     * the Decoder interface, and will throw a DecoderException if the supplied object is not of type byte[] or String.
+     *
+     * @param obj
+     *            Object to decode
+     * @return An object (of type byte[]) containing the binary data which corresponds to the byte[] or String
+     *         supplied.
+     * @throws DecoderException
+     *             if the parameter supplied is not of type byte[]
+     */
+    @Override
+    public Object decode(final Object obj) throws DecoderException {
+        if (obj instanceof byte[]) {
+            return decode((byte[]) obj);
+        } else if (obj instanceof String) {
+            return decode((String) obj);
+        } else {
+            throw new DecoderException("Parameter supplied to Base-N decode is not a byte[] or a String");
+        }
+    }
+
+    /**
+     * Decodes a String containing characters in the Base-N alphabet.
+     *
+     * @param pArray
+     *            A String containing Base-N character data
+     * @return a byte array containing binary data
+     */
+    public byte[] decode(final String pArray) {
+        return decode(StringUtils.getBytesUtf8(pArray));
+    }
+
+    /**
+     * Decodes a byte[] containing characters in the Base-N alphabet.
+     *
+     * @param pArray
+     *            A byte array containing Base-N character data
+     * @return a byte array containing binary data
+     */
+    @Override
+    public byte[] decode(final byte[] pArray) {
+        if (pArray == null || pArray.length == 0) {
+            return pArray;
+        }
+        final Context context = new Context();
+        decode(pArray, 0, pArray.length, context);
+        decode(pArray, 0, EOF, context); // Notify decoder of EOF.
+        final byte[] result = new byte[context.pos];
+        readResults(result, 0, result.length, context);
+        return result;
+    }
+
+    /**
+     * Encodes a byte[] containing binary data, into a byte[] containing characters in the alphabet.
+     *
+     * @param pArray
+     *            a byte array containing binary data
+     * @return A byte array containing only the base N alphabetic character data
+     */
+    @Override
+    public byte[] encode(final byte[] pArray) {
+        if (pArray == null || pArray.length == 0) {
+            return pArray;
+        }
+        return encode(pArray, 0, pArray.length);
+    }
+
+    /**
+     * Encodes a byte[] containing binary data, into a byte[] containing
+     * characters in the alphabet.
+     *
+     * @param pArray
+     *            a byte array containing binary data
+     * @param offset
+     *            initial offset of the subarray.
+     * @param length
+     *            length of the subarray.
+     * @return A byte array containing only the base N alphabetic character data
+     * @since 1.11
+     */
+    public byte[] encode(final byte[] pArray, final int offset, final int length) {
+        if (pArray == null || pArray.length == 0) {
+            return pArray;
+        }
+        final Context context = new Context();
+        encode(pArray, offset, length, context);
+        encode(pArray, offset, EOF, context); // Notify encoder of EOF.
+        final byte[] buf = new byte[context.pos - context.readPos];
+        readResults(buf, 0, buf.length, context);
+        return buf;
+    }
+
+    // package protected for access from I/O streams
+    abstract void encode(byte[] pArray, int i, int length, Context context);
+
+    // package protected for access from I/O streams
+    abstract void decode(byte[] pArray, int i, int length, Context context);
+
+    /**
+     * Returns whether or not the <code>octet</code> is in the current alphabet.
+     * Does not allow whitespace or pad.
+     *
+     * @param value The value to test
+     *
+     * @return <code>true</code> if the value is defined in the current alphabet, <code>false</code> otherwise.
+     */
+    protected abstract boolean isInAlphabet(byte value);
+
+    /**
+     * Tests a given byte array to see if it contains only valid characters within the alphabet.
+     * The method optionally treats whitespace and pad as valid.
+     *
+     * @param arrayOctet byte array to test
+     * @param allowWSPad if <code>true</code>, then whitespace and PAD are also allowed
+     *
+     * @return <code>true</code> if all bytes are valid characters in the alphabet or if the byte array is empty;
+     *         <code>false</code>, otherwise
+     */
+    public boolean isInAlphabet(final byte[] arrayOctet, final boolean allowWSPad) {
+        for (final byte octet : arrayOctet) {
+            if (!isInAlphabet(octet) &&
+                    (!allowWSPad || (octet != pad) && !isWhiteSpace(octet))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Tests a given String to see if it contains only valid characters within the alphabet.
+     * The method treats whitespace and PAD as valid.
+     *
+     * @param basen String to test
+     * @return <code>true</code> if all characters in the String are valid characters in the alphabet or if
+     *         the String is empty; <code>false</code>, otherwise
+     * @see #isInAlphabet(byte[], boolean)
+     */
+    public boolean isInAlphabet(final String basen) {
+        return isInAlphabet(StringUtils.getBytesUtf8(basen), true);
+    }
+
+    /**
+     * Tests a given byte array to see if it contains any characters within the alphabet or PAD.
+     *
+     * Intended for use in checking line-ending arrays
+     *
+     * @param arrayOctet
+     *            byte array to test
+     * @return <code>true</code> if any byte is a valid character in the alphabet or PAD; <code>false</code> otherwise
+     */
+    protected boolean containsAlphabetOrPad(final byte[] arrayOctet) {
+        if (arrayOctet == null) {
+            return false;
+        }
+        for (final byte element : arrayOctet) {
+            if (pad == element || isInAlphabet(element)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Calculates the amount of space needed to encode the supplied array.
+     *
+     * @param pArray byte[] array which will later be encoded
+     *
+     * @return amount of space needed to encoded the supplied array.
+     * Returns a long since a max-len array will require &gt; Integer.MAX_VALUE
+     */
+    public long getEncodedLength(final byte[] pArray) {
+        // Calculate non-chunked size - rounded up to allow for padding
+        // cast to long is needed to avoid possibility of overflow
+        long len = ((pArray.length + unencodedBlockSize-1)  / unencodedBlockSize) * (long) encodedBlockSize;
+        if (lineLength > 0) { // We're using chunking
+            // Round up to nearest multiple
+            len += ((len + lineLength-1) / lineLength) * chunkSeparatorLength;
+        }
+        return len;
+    }
+}

--- a/aTalk/src/main/java/org2/apache/commons/codec/binary/CharSequenceUtils.java
+++ b/aTalk/src/main/java/org2/apache/commons/codec/binary/CharSequenceUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org2.apache.commons.codec.binary;
+
+/**
+ * <p>
+ * Operations on {@link CharSequence} that are <code>null</code> safe.
+ * </p>
+ * <p>
+ * Copied from Apache Commons Lang r1586295 on April 10, 2014 (day of 3.3.2 release).
+ * </p>
+ *
+ * @see CharSequence
+ * @since 1.10
+ */
+public class CharSequenceUtils {
+
+    /**
+     * Green implementation of regionMatches.
+     *
+     * @param cs
+     *            the <code>CharSequence</code> to be processed
+     * @param ignoreCase
+     *            whether or not to be case insensitive
+     * @param thisStart
+     *            the index to start on the <code>cs</code> CharSequence
+     * @param substring
+     *            the <code>CharSequence</code> to be looked for
+     * @param start
+     *            the index to start on the <code>substring</code> CharSequence
+     * @param length
+     *            character length of the region
+     * @return whether the region matched
+     */
+    static boolean regionMatches(final CharSequence cs, final boolean ignoreCase, final int thisStart,
+            final CharSequence substring, final int start, final int length) {
+        if (cs instanceof String && substring instanceof String) {
+            return ((String) cs).regionMatches(ignoreCase, thisStart, (String) substring, start, length);
+        }
+        int index1 = thisStart;
+        int index2 = start;
+        int tmpLen = length;
+
+        while (tmpLen-- > 0) {
+            final char c1 = cs.charAt(index1++);
+            final char c2 = substring.charAt(index2++);
+
+            if (c1 == c2) {
+                continue;
+            }
+
+            if (!ignoreCase) {
+                return false;
+            }
+
+            // The same check as in String.regionMatches():
+            if (Character.toUpperCase(c1) != Character.toUpperCase(c2) &&
+                    Character.toLowerCase(c1) != Character.toLowerCase(c2)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/aTalk/src/main/java/org2/apache/commons/codec/binary/StringUtils.java
+++ b/aTalk/src/main/java/org2/apache/commons/codec/binary/StringUtils.java
@@ -1,0 +1,420 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org2.apache.commons.codec.binary;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.codec.Charsets;
+
+/**
+ * Converts String to and from bytes using the encodings required by the Java specification. These encodings are
+ * specified in <a href="http://download.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html">
+ * Standard charsets</a>.
+ *
+ * <p>This class is immutable and thread-safe.</p>
+ *
+ * @see CharEncoding
+ * @see <a href="http://download.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
+ * @version $Id: StringUtils.java 1789539 2017-03-30 16:36:28Z sebb $
+ * @since 1.4
+ */
+public class StringUtils {
+
+    /**
+     * <p>
+     * Compares two CharSequences, returning <code>true</code> if they represent equal sequences of characters.
+     * </p>
+     *
+     * <p>
+     * <code>null</code>s are handled without exceptions. Two <code>null</code> references are considered to be equal.
+     * The comparison is case sensitive.
+     * </p>
+     *
+     * <pre>
+     * StringUtils.equals(null, null)   = true
+     * StringUtils.equals(null, "abc")  = false
+     * StringUtils.equals("abc", null)  = false
+     * StringUtils.equals("abc", "abc") = true
+     * StringUtils.equals("abc", "ABC") = false
+     * </pre>
+     *
+     * <p>
+     * Copied from Apache Commons Lang r1583482 on April 10, 2014 (day of 3.3.2 release).
+     * </p>
+     *
+     * @see Object#equals(Object)
+     * @param cs1
+     *            the first CharSequence, may be <code>null</code>
+     * @param cs2
+     *            the second CharSequence, may be <code>null</code>
+     * @return <code>true</code> if the CharSequences are equal (case-sensitive), or both <code>null</code>
+     * @since 1.10
+     */
+    public static boolean equals(final CharSequence cs1, final CharSequence cs2) {
+        if (cs1 == cs2) {
+            return true;
+        }
+        if (cs1 == null || cs2 == null) {
+            return false;
+        }
+        if (cs1 instanceof String && cs2 instanceof String) {
+            return cs1.equals(cs2);
+        }
+        return cs1.length() == cs2.length() && CharSequenceUtils.regionMatches(cs1, false, 0, cs2, 0, cs1.length());
+    }
+
+    /**
+     * Calls {@link String#getBytes(Charset)}
+     *
+     * @param string
+     *            The string to encode (if null, return null).
+     * @param charset
+     *            The {@link Charset} to encode the <code>String</code>
+     * @return the encoded bytes
+     */
+    private static byte[] getBytes(final String string, final Charset charset) {
+        if (string == null) {
+            return null;
+        }
+        return string.getBytes(charset);
+    }
+
+    /**
+     * Calls {@link String#getBytes(Charset)}
+     *
+     * @param string
+     *            The string to encode (if null, return null).
+     * @param charset
+     *            The {@link Charset} to encode the <code>String</code>
+     * @return the encoded bytes
+     */
+    private static ByteBuffer getByteBuffer(final String string, final Charset charset) {
+        if (string == null) {
+            return null;
+        }
+        return ByteBuffer.wrap(string.getBytes(charset));
+    }
+
+    /**
+     * Encodes the given string into a byte buffer using the UTF-8 charset, storing the result into a new byte
+     * array.
+     *
+     * @param string
+     *            the String to encode, may be <code>null</code>
+     * @return encoded bytes, or <code>null</code> if the input string was <code>null</code>
+     * @throws NullPointerException
+     *             Thrown if {@link Charsets#UTF_8} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @see <a href="http://download.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
+     * @see #getBytesUnchecked(String, String)
+     * @since 1.11
+     */
+    public static ByteBuffer getByteBufferUtf8(final String string) {
+        return getByteBuffer(string, Charsets.UTF_8);
+    }
+
+    /**
+     * Encodes the given string into a sequence of bytes using the ISO-8859-1 charset, storing the result into a new
+     * byte array.
+     *
+     * @param string
+     *            the String to encode, may be <code>null</code>
+     * @return encoded bytes, or <code>null</code> if the input string was <code>null</code>
+     * @throws NullPointerException
+     *             Thrown if {@link Charsets#ISO_8859_1} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException
+     * @see <a href="http://download.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
+     * @see #getBytesUnchecked(String, String)
+     */
+    public static byte[] getBytesIso8859_1(final String string) {
+        return getBytes(string, Charsets.ISO_8859_1);
+    }
+
+
+    /**
+     * Encodes the given string into a sequence of bytes using the named charset, storing the result into a new byte
+     * array.
+     * <p>
+     * This method catches {@link UnsupportedEncodingException} and rethrows it as {@link IllegalStateException}, which
+     * should never happen for a required charset name. Use this method when the encoding is required to be in the JRE.
+     * </p>
+     *
+     * @param string
+     *            the String to encode, may be <code>null</code>
+     * @param charsetName
+     *            The name of a required {@link java.nio.charset.Charset}
+     * @return encoded bytes, or <code>null</code> if the input string was <code>null</code>
+     * @throws IllegalStateException
+     *             Thrown when a {@link UnsupportedEncodingException} is caught, which should never happen for a
+     *             required charset name.
+     * @see CharEncoding
+     * @see String#getBytes(String)
+     */
+    public static byte[] getBytesUnchecked(final String string, final String charsetName) {
+        if (string == null) {
+            return null;
+        }
+        try {
+            return string.getBytes(charsetName);
+        } catch (final UnsupportedEncodingException e) {
+            throw StringUtils.newIllegalStateException(charsetName, e);
+        }
+    }
+
+    /**
+     * Encodes the given string into a sequence of bytes using the US-ASCII charset, storing the result into a new byte
+     * array.
+     *
+     * @param string
+     *            the String to encode, may be <code>null</code>
+     * @return encoded bytes, or <code>null</code> if the input string was <code>null</code>
+     * @throws NullPointerException
+     *             Thrown if {@link Charsets#US_ASCII} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException
+     * @see <a href="http://download.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
+     * @see #getBytesUnchecked(String, String)
+     */
+    public static byte[] getBytesUsAscii(final String string) {
+        return getBytes(string, Charsets.US_ASCII);
+    }
+
+    /**
+     * Encodes the given string into a sequence of bytes using the UTF-16 charset, storing the result into a new byte
+     * array.
+     *
+     * @param string
+     *            the String to encode, may be <code>null</code>
+     * @return encoded bytes, or <code>null</code> if the input string was <code>null</code>
+     * @throws NullPointerException
+     *             Thrown if {@link Charsets#UTF_16} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException
+     * @see <a href="http://download.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
+     * @see #getBytesUnchecked(String, String)
+     */
+    public static byte[] getBytesUtf16(final String string) {
+        return getBytes(string, Charsets.UTF_16);
+    }
+
+    /**
+     * Encodes the given string into a sequence of bytes using the UTF-16BE charset, storing the result into a new byte
+     * array.
+     *
+     * @param string
+     *            the String to encode, may be <code>null</code>
+     * @return encoded bytes, or <code>null</code> if the input string was <code>null</code>
+     * @throws NullPointerException
+     *             Thrown if {@link Charsets#UTF_16BE} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException
+     * @see <a href="http://download.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
+     * @see #getBytesUnchecked(String, String)
+     */
+    public static byte[] getBytesUtf16Be(final String string) {
+        return getBytes(string, Charsets.UTF_16BE);
+    }
+
+    /**
+     * Encodes the given string into a sequence of bytes using the UTF-16LE charset, storing the result into a new byte
+     * array.
+     *
+     * @param string
+     *            the String to encode, may be <code>null</code>
+     * @return encoded bytes, or <code>null</code> if the input string was <code>null</code>
+     * @throws NullPointerException
+     *             Thrown if {@link Charsets#UTF_16LE} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException
+     * @see <a href="http://download.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
+     * @see #getBytesUnchecked(String, String)
+     */
+    public static byte[] getBytesUtf16Le(final String string) {
+        return getBytes(string, Charsets.UTF_16LE);
+    }
+
+    /**
+     * Encodes the given string into a sequence of bytes using the UTF-8 charset, storing the result into a new byte
+     * array.
+     *
+     * @param string
+     *            the String to encode, may be <code>null</code>
+     * @return encoded bytes, or <code>null</code> if the input string was <code>null</code>
+     * @throws NullPointerException
+     *             Thrown if {@link Charsets#UTF_8} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException
+     * @see <a href="http://download.oracle.com/javase/6/docs/api/java/nio/charset/Charset.html">Standard charsets</a>
+     * @see #getBytesUnchecked(String, String)
+     */
+    public static byte[] getBytesUtf8(final String string) {
+        return getBytes(string, Charsets.UTF_8);
+    }
+
+    private static IllegalStateException newIllegalStateException(final String charsetName,
+                                                                  final UnsupportedEncodingException e) {
+        return new IllegalStateException(charsetName + ": " + e);
+    }
+
+    /**
+     * Constructs a new <code>String</code> by decoding the specified array of bytes using the given charset.
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters
+     * @param charset
+     *            The {@link Charset} to encode the <code>String</code>; not {@code null}
+     * @return A new <code>String</code> decoded from the specified array of bytes using the given charset,
+     *         or <code>null</code> if the input byte array was <code>null</code>.
+     * @throws NullPointerException
+     *             Thrown if charset is {@code null}
+     */
+    private static String newString(final byte[] bytes, final Charset charset) {
+        return bytes == null ? null : new String(bytes, charset);
+    }
+
+    /**
+     * Constructs a new <code>String</code> by decoding the specified array of bytes using the given charset.
+     * <p>
+     * This method catches {@link UnsupportedEncodingException} and re-throws it as {@link IllegalStateException}, which
+     * should never happen for a required charset name. Use this method when the encoding is required to be in the JRE.
+     * </p>
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters, may be <code>null</code>
+     * @param charsetName
+     *            The name of a required {@link java.nio.charset.Charset}
+     * @return A new <code>String</code> decoded from the specified array of bytes using the given charset,
+     *         or <code>null</code> if the input byte array was <code>null</code>.
+     * @throws IllegalStateException
+     *             Thrown when a {@link UnsupportedEncodingException} is caught, which should never happen for a
+     *             required charset name.
+     * @see CharEncoding
+     * @see String#String(byte[], String)
+     */
+    public static String newString(final byte[] bytes, final String charsetName) {
+        if (bytes == null) {
+            return null;
+        }
+        try {
+            return new String(bytes, charsetName);
+        } catch (final UnsupportedEncodingException e) {
+            throw StringUtils.newIllegalStateException(charsetName, e);
+        }
+    }
+
+    /**
+     * Constructs a new <code>String</code> by decoding the specified array of bytes using the ISO-8859-1 charset.
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters, may be <code>null</code>
+     * @return A new <code>String</code> decoded from the specified array of bytes using the ISO-8859-1 charset, or
+     *         <code>null</code> if the input byte array was <code>null</code>.
+     * @throws NullPointerException
+     *             Thrown if {@link Charsets#ISO_8859_1} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException
+     */
+    public static String newStringIso8859_1(final byte[] bytes) {
+        return newString(bytes, Charsets.ISO_8859_1);
+    }
+
+    /**
+     * Constructs a new <code>String</code> by decoding the specified array of bytes using the US-ASCII charset.
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters
+     * @return A new <code>String</code> decoded from the specified array of bytes using the US-ASCII charset,
+     *         or <code>null</code> if the input byte array was <code>null</code>.
+     * @throws NullPointerException
+     *             Thrown if {@link Charsets#US_ASCII} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException
+     */
+    public static String newStringUsAscii(final byte[] bytes) {
+        return newString(bytes, Charsets.US_ASCII);
+    }
+
+    /**
+     * Constructs a new <code>String</code> by decoding the specified array of bytes using the UTF-16 charset.
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters
+     * @return A new <code>String</code> decoded from the specified array of bytes using the UTF-16 charset
+     *         or <code>null</code> if the input byte array was <code>null</code>.
+     * @throws NullPointerException
+     *             Thrown if {@link Charsets#UTF_16} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException
+     */
+    public static String newStringUtf16(final byte[] bytes) {
+        return newString(bytes, Charsets.UTF_16);
+    }
+
+    /**
+     * Constructs a new <code>String</code> by decoding the specified array of bytes using the UTF-16BE charset.
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters
+     * @return A new <code>String</code> decoded from the specified array of bytes using the UTF-16BE charset,
+     *         or <code>null</code> if the input byte array was <code>null</code>.
+     * @throws NullPointerException
+     *             Thrown if {@link Charsets#UTF_16BE} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException
+     */
+    public static String newStringUtf16Be(final byte[] bytes) {
+        return newString(bytes, Charsets.UTF_16BE);
+    }
+
+    /**
+     * Constructs a new <code>String</code> by decoding the specified array of bytes using the UTF-16LE charset.
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters
+     * @return A new <code>String</code> decoded from the specified array of bytes using the UTF-16LE charset,
+     *         or <code>null</code> if the input byte array was <code>null</code>.
+     * @throws NullPointerException
+     *             Thrown if {@link Charsets#UTF_16LE} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException
+     */
+    public static String newStringUtf16Le(final byte[] bytes) {
+        return newString(bytes, Charsets.UTF_16LE);
+    }
+
+    /**
+     * Constructs a new <code>String</code> by decoding the specified array of bytes using the UTF-8 charset.
+     *
+     * @param bytes
+     *            The bytes to be decoded into characters
+     * @return A new <code>String</code> decoded from the specified array of bytes using the UTF-8 charset,
+     *         or <code>null</code> if the input byte array was <code>null</code>.
+     * @throws NullPointerException
+     *             Thrown if {@link Charsets#UTF_8} is not initialized, which should never happen since it is
+     *             required by the Java platform specification.
+     * @since As of 1.7, throws {@link NullPointerException} instead of UnsupportedEncodingException
+     */
+    public static String newStringUtf8(final byte[] bytes) {
+        return newString(bytes, Charsets.UTF_8);
+    }
+
+}


### PR DESCRIPTION
This is a possible fix for the issue:

No static method decodeBase64(Ljava/lang/String;)[B in class Lorg/apache/commons/codec/binary/Base64; or its super classes

https://github.com/cmeng-git/atalk-android/issues/91

After the fix SDES works correctly.

The library ch.imvs.sdes4j is directly included in the source code.
Imports for org.apache.commons.codec.binary are replaced with
a local copy org2.apache.commons.codec.binary .
