### PR TITLE
Disable support for SSLv3 in TLS connections.

### DIFF
--- a/aTalk/src/main/java/net/java/sip/communicator/impl/protocol/jabber/ProtocolProviderServiceJabberImpl.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/impl/protocol/jabber/ProtocolProviderServiceJabberImpl.java
@@ -983,7 +983,7 @@ public class ProtocolProviderServiceJabberImpl extends AbstractProtocolProviderS
             disconnectAndCleanConnection();
         }
         config.setSocketFactory(SocketFactory.getDefault());
-        TLSUtils.setSSLv3AndTLSOnly(config);
+        TLSUtils.setTLSOnly(config);
 
         // Cannot use a custom SSL context with DNSSEC enabled
         String dnssecMode = mAccountID.getDnssMode();


### PR DESCRIPTION
SSLv3 is effectively broken by POODLE attack.
Disable support for SSLv3.

https://blog.mozilla.org/security/2014/10/14/the-poodle-attack-and-the-end-of-ssl-3-0/
https://security.googleblog.com/2014/10/this-poodle-bites-exploiting-ssl-30.html
https://disablessl3.com/