### PR TITLE
Minimum TLS Protocol version should be TLS 1.2

### DIFF
--- a/aTalk/src/main/java/net/java/sip/communicator/service/protocol/ProtocolProviderFactory.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/service/protocol/ProtocolProviderFactory.java
@@ -425,6 +425,11 @@ public abstract class ProtocolProviderFactory
     public static final String USE_JITSI_VIDEO_BRIDGE = "USE_JITSI_VIDEO_BRIDGE";
 
     /**
+     * Minimum TLS protocol version.
+     */
+    public static final String MINUMUM_TLS_VERSION = "MINUMUM_TLS_VERSION";
+
+    /**
      * Indicates if we allow non-TLS connection.
      */
     public static final String IS_ALLOW_NON_SECURE = "ALLOW_NON_SECURE";

--- a/aTalk/src/main/java/net/java/sip/communicator/service/protocol/jabber/JabberAccountID.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/service/protocol/jabber/JabberAccountID.java
@@ -9,6 +9,7 @@ import net.java.sip.communicator.service.protocol.*;
 
 import org.atalk.android.gui.account.settings.BoshProxyDialog;
 import org.atalk.service.configuration.ConfigurationService;
+import org.jivesoftware.smack.util.TLSUtils;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.stringprep.XmppStringprepException;
 import org.jxmpp.util.XmppStringUtils;
@@ -488,6 +489,26 @@ public class JabberAccountID extends AccountID
     public void setUseUPNP(boolean isUseUPNP)
     {
         putAccountProperty(ProtocolProviderFactory.IS_USE_UPNP, isUseUPNP);
+    }
+
+    /**
+     * Minimum TLS protocol version used for TLS connections.
+     *
+     * @return minimum TLS protocol version. Default TLS 1.2
+     */
+    public String getMinimumTLSversion()
+    {
+        return getAccountPropertyString(ProtocolProviderFactory.MINUMUM_TLS_VERSION, TLSUtils.PROTO_TLSV1_2);
+    }
+
+    /**
+     * Sets the <tt>minimumTLSversion</tt> property.
+     *
+     * @param minimumTLSversion minimum TLS protocol version
+     */
+    public void setMinimumTLSversion(String minimumTLSversion)
+    {
+        putAccountProperty(ProtocolProviderFactory.MINUMUM_TLS_VERSION, minimumTLSversion);
     }
 
     /**

--- a/aTalk/src/main/java/org/atalk/android/gui/account/settings/JabberPreferenceFragment.java
+++ b/aTalk/src/main/java/org/atalk/android/gui/account/settings/JabberPreferenceFragment.java
@@ -24,6 +24,11 @@ import org.atalk.android.aTalkApp;
 import org.atalk.android.gui.dialogs.DialogActivity;
 import org.atalk.android.gui.settings.util.SummaryMapper;
 
+import java.io.IOException;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
 import timber.log.Timber;
 
 /**
@@ -72,6 +77,8 @@ public class JabberPreferenceFragment extends AccountPreferenceFragment
     public static final String P_KEY_SERVER_PORT = aTalkApp.getResString(R.string.pref_key_server_port);
     private static final String P_KEY_ALLOW_NON_SECURE_CONN = aTalkApp.getAppResources()
             .getString(R.string.pref_key_allow_non_secure_conn);
+    private static final String P_KEY_MINIMUM_TLS_VERSION = aTalkApp.getAppResources()
+            .getString(R.string.pref_key_minimum_TLS_version);
 
     // Jabber Resource
     private static final String P_KEY_AUTO_GEN_RESOURCE = aTalkApp.getResString(R.string.pref_key_auto_gen_resource);
@@ -175,6 +182,7 @@ public class JabberPreferenceFragment extends AccountPreferenceFragment
         // Connection
         editor.putBoolean(P_KEY_GMAIL_NOTIFICATIONS, jbrReg.isGmailNotificationEnabled());
         editor.putBoolean(P_KEY_GOOGLE_CONTACTS_ENABLED, jbrReg.isGoogleContactsEnabled());
+        editor.putString(P_KEY_MINIMUM_TLS_VERSION, jbrReg.getMinimumTLSversion());
         editor.putBoolean(P_KEY_ALLOW_NON_SECURE_CONN, jbrReg.isAllowNonSecure());
         editor.putString(P_KEY_DTMF_METHOD, jbrReg.getDTMFMethod());
 
@@ -349,6 +357,36 @@ public class JabberPreferenceFragment extends AccountPreferenceFragment
         }
         else if (key.equals(P_KEY_GOOGLE_CONTACTS_ENABLED)) {
             jbrReg.setGoogleContactsEnabled(shPrefs.getBoolean(P_KEY_GOOGLE_CONTACTS_ENABLED, false));
+        }
+        else if (key.equals(P_KEY_MINIMUM_TLS_VERSION)) {
+
+            String newMinimumTLSVersion = shPrefs.getString(P_KEY_MINIMUM_TLS_VERSION,
+                    ProtocolProviderServiceJabberImpl.defaultMinimumTLSversion);
+
+            boolean isSupported = false;
+            try
+            {
+                String supportedProtocols[] =
+                        ((SSLSocket) SSLSocketFactory.getDefault().createSocket()).getSupportedProtocols();
+
+                for (String suppProto : supportedProtocols)
+                {
+                    if (suppProto.equals(newMinimumTLSVersion))
+                    {
+                        isSupported = true;
+                        break;
+                    }
+                }
+
+            } catch (IOException e)
+            {
+            }
+
+            if (!isSupported)
+            {
+                newMinimumTLSVersion = ProtocolProviderServiceJabberImpl.defaultMinimumTLSversion;
+            }
+            jbrReg.setMinimumTLSversion(newMinimumTLSVersion);
         }
         else if (key.equals(P_KEY_ALLOW_NON_SECURE_CONN)) {
             jbrReg.setAllowNonSecure(shPrefs.getBoolean(P_KEY_ALLOW_NON_SECURE_CONN, false));

--- a/aTalk/src/main/res/values/array.xml
+++ b/aTalk/src/main/res/values/array.xml
@@ -383,4 +383,17 @@
         <item>ru</item>
     </string-array>
 
+    <string-array name="TLS_version_name">
+        <item>TLS 1.3</item>
+        <item>TLS 1.2</item>
+        <item>TLS 1.1</item>
+        <item>TLS 1.0</item>
+    </string-array>
+    <string-array name="TLS_version_value">
+        <item>TLSv1.3</item>
+        <item>TLSv1.2</item>
+        <item>TLSv1.1</item>
+        <item>TLSv1</item>
+    </string-array>
+
 </resources>

--- a/aTalk/src/main/res/values/strings.xml
+++ b/aTalk/src/main/res/values/strings.xml
@@ -1198,6 +1198,7 @@
     <!-- Jabber preferences -->
     <string name="service_gui_JBR_ADVANCED">Advanced</string>
     <string name="service_gui_JBR_ALLOW_NON_SECURE">Allow non-secure connections</string>
+    <string name="service_gui_JBR_MINIMUM_TLS">Minimum TLS version</string>
     <string name="service_gui_JBR_AUTO_SIGNIN">Connect at Startup</string>
     <string name="service_gui_JBR_AUTO_STUN_DICOVERY">Auto discover STUN/TURN servers</string>
     <string name="service_gui_JBR_CONN_GENERAL">General</string>
@@ -1235,6 +1236,7 @@
     <string name="service_gui_JBR_SERVER">Connect Server IP</string>
     <string name="service_gui_JBR_SERVER_OPTIONS">Server options</string>
     <string name="service_gui_JBR_SSL_SUMMARY">Disable SSL/TLS server connection encryption</string>
+    <string name="service_gui_JBR_MINIMUM_TLS_SUMMARY">Connect using this or higher TLS protocol version</string>
     <string name="service_gui_JBR_STORE_PASSWORD">Remember password</string>
     <string name="service_gui_JBR_STORE_PASSWORD_SUMMARY">Save password for auto login on application start up</string>
     <string name="service_gui_JBR_STUN_LIST">Additional STUN/TURN servers&#8230;</string>
@@ -1321,6 +1323,7 @@
     <string name="pref_key_clist_user">pref_key_clist_user</string>
 
     <!-- Not present int SIP, but new in XMPP -->
+    <string name="pref_key_minimum_TLS_version">pref_key_minimum_TLS_version</string>
     <string name="pref_key_allow_non_secure_conn">pref_key_allow_non_secure_conn</string>
     <string name="pref_key_auto_gen_resource">pref_key_auto_gen_resource</string>
     <string name="pref_key_gmail_notifications">pref_key_gmail_notifications</string>

--- a/aTalk/src/main/res/xml/acc_jabber_preferences.xml
+++ b/aTalk/src/main/res/xml/acc_jabber_preferences.xml
@@ -80,6 +80,12 @@
                     android:inputType="number"
                     android:key="@string/pref_key_server_port"
                     android:title="@string/service_gui_JBR_PORT" />
+                <ListPreference
+                    android:entries="@array/TLS_version_name"
+                    android:entryValues="@array/TLS_version_value"
+                    android:key="@string/pref_key_minimum_TLS_version"
+                    android:summary="@string/service_gui_JBR_MINIMUM_TLS_SUMMARY"
+                    android:title="@string/service_gui_JBR_MINIMUM_TLS" />
                 <CheckBoxPreference
                     android:key="@string/pref_key_allow_non_secure_conn"
                     android:summary="@string/service_gui_JBR_SSL_SUMMARY"


### PR DESCRIPTION
There have been multiple security attacks on TLS 1.0, TLS 1.1 .
In October 2018, Apple, Google, Microsoft, and Mozilla jointly announced
they would deprecate TLS 1.0 and 1.1 in March 2020.
https://webkit.org/blog/8462/deprecation-of-legacy-tls-1-0-and-1-1-versions/
https://blog.mozilla.org/security/2018/10/15/removing-old-versions-of-tls/
https://security.googleblog.com/2018/10/modernizing-transport-security.html

According to stats from
https://xmpp.net/reports.php
over 97% of public XMPP servers support TLS 1.2