### PR TITLE
Using <zrtp-hash/> element check the integrity of the ZRTP key exchange.

### DIFF
--- a/aTalk/src/main/java/net/java/sip/communicator/impl/protocol/jabber/CallPeerMediaHandlerJabberImpl.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/impl/protocol/jabber/CallPeerMediaHandlerJabberImpl.java
@@ -2130,6 +2130,15 @@ public class CallPeerMediaHandlerJabberImpl extends CallPeerMediaHandler<CallPee
 
                 if ((zrtpHashPacketExtension != null) && (zrtpHashPacketExtension.getValue() != null)) {
                     addAdvertisedEncryptionMethod(SrtpControlType.ZRTP);
+
+                    ZrtpControl zrtpControl
+                            = (ZrtpControl) getSrtpControls().get(mediaType, SrtpControlType.ZRTP);
+
+                    if (zrtpControl != null)
+                    {
+                        zrtpControl.setReceivedSignaledZRTPVersion(zrtpHashPacketExtension.getVersion());
+                        zrtpControl.setReceivedSignaledZRTPHashValue(zrtpHashPacketExtension.getValue());
+                    }
                 }
             }
         }
@@ -2275,6 +2284,22 @@ public class CallPeerMediaHandlerJabberImpl extends CallPeerMediaHandler<CallPee
                 ZrtpControl zrtpControl
                         = (ZrtpControl) getSrtpControls().getOrCreate(mediaType, SrtpControlType.ZRTP);
                 int numberSupportedVersions = zrtpControl.getNumberSupportedVersions();
+
+                // Try to get the remote ZRTP version and hash value
+                if (remoteDescription != null) {
+                    EncryptionExtensionElement remoteEncryption
+                            = remoteDescription.getFirstChildOfType(EncryptionExtensionElement.class);
+
+                    if (remoteEncryption != null) {
+                        ZrtpHashExtensionElement zrtpHashPacketExtension
+                                = remoteEncryption.getFirstChildOfType(ZrtpHashExtensionElement.class);
+
+                        if ((zrtpHashPacketExtension != null) && (zrtpHashPacketExtension.getValue() != null)) {
+                            zrtpControl.setReceivedSignaledZRTPVersion(zrtpHashPacketExtension.getVersion());
+                            zrtpControl.setReceivedSignaledZRTPHashValue(zrtpHashPacketExtension.getValue());
+                        }
+                    }
+                }
 
                 for (int i = 0; i < numberSupportedVersions; i++) {
                     String[] helloHash = zrtpControl.getHelloHashSep(i);

--- a/aTalk/src/main/java/org/atalk/impl/neomedia/transform/zrtp/ZRTPTransformEngine.java
+++ b/aTalk/src/main/java/org/atalk/impl/neomedia/transform/zrtp/ZRTPTransformEngine.java
@@ -370,6 +370,16 @@ public class ZRTPTransformEngine extends SinglePacketTransformer implements Srtp
     private boolean disposed = false;
 
     /**
+     * This is the peer ZRTP version received from the signaling layer.
+     */
+    private String receivedSignaledZRTPVersion = null;
+
+    /**
+     * This is the peer ZRTP hash value received from the signaling layer.
+     */
+    private String receivedSignaledZRTPHashValue = null;
+
+    /**
      * Construct a ZRTPTransformEngine.
      */
     public ZRTPTransformEngine()
@@ -920,6 +930,22 @@ public class ZRTPTransformEngine extends SinglePacketTransformer implements Srtp
      */
     public void sendInfo(ZrtpCodes.MessageSeverity severity, EnumSet<?> subCode)
     {
+        final String version_and_hash[] = zrtpEngine.getPeerHelloHashSep();
+
+        if (version_and_hash != null) {
+            final String peerHelloVersion = version_and_hash[0];
+            final String peerHelloHash = version_and_hash[1];
+
+            if (!peerHelloVersion.equals(receivedSignaledZRTPVersion)
+                    || !peerHelloHash.equals(receivedSignaledZRTPHashValue))
+            {
+                if (securityEventManager != null) {
+                    securityEventManager.showMessage(ZrtpCodes.MessageSeverity.Severe, EnumSet.of(ZrtpCodes.SevereCodes.SevereSecurityException));
+                }
+                close();
+            }
+        }
+
         if (securityEventManager != null)
             securityEventManager.showMessage(severity, subCode);
     }
@@ -1381,5 +1407,21 @@ public class ZRTPTransformEngine extends SinglePacketTransformer implements Srtp
     public int getCurrentProtocolVersion()
     {
         return (zrtpEngine != null) ? zrtpEngine.getCurrentProtocolVersion() : 0;
+    }
+
+    /**
+     * Set ZRTP version received from the signaling layer.
+     * @param version received version
+     */
+    public void setReceivedSignaledZRTPVersion(final String version) {
+        this.receivedSignaledZRTPVersion = version;
+    }
+
+    /**
+     * Set ZRTP hash value received from the signaling layer.
+     * @param value hash value
+     */
+    public void setReceivedSignaledZRTPHashValue(final String value) {
+        this.receivedSignaledZRTPHashValue = value;
     }
 }

--- a/aTalk/src/main/java/org/atalk/impl/neomedia/transform/zrtp/ZRTPTransformEngine.java
+++ b/aTalk/src/main/java/org/atalk/impl/neomedia/transform/zrtp/ZRTPTransformEngine.java
@@ -932,7 +932,9 @@ public class ZRTPTransformEngine extends SinglePacketTransformer implements Srtp
     {
         final String version_and_hash[] = zrtpEngine.getPeerHelloHashSep();
 
-        if (version_and_hash != null) {
+        if (version_and_hash != null
+            && receivedSignaledZRTPVersion != null
+            && receivedSignaledZRTPHashValue != null) {
             final String peerHelloVersion = version_and_hash[0];
             final String peerHelloHash = version_and_hash[1];
 

--- a/aTalk/src/main/java/org/atalk/impl/neomedia/transform/zrtp/ZrtpControlImpl.java
+++ b/aTalk/src/main/java/org/atalk/impl/neomedia/transform/zrtp/ZrtpControlImpl.java
@@ -345,4 +345,22 @@ public class ZrtpControlImpl extends AbstractSrtpControl<ZRTPTransformEngine> im
         engine.sendInfo(
                 ZrtpCodes.MessageSeverity.Info, EnumSet.of(ZRTPCustomInfoCodes.ZRTPEnabledByDefault));
     }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see net.java.sip.communicator.service.neomedia.ZrtpControl#setReceivedSignaledZRTPVersion(String)
+     */
+    public void setReceivedSignaledZRTPVersion(final String version) {
+        getTransformEngine().setReceivedSignaledZRTPVersion(version);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see net.java.sip.communicator.service.neomedia.ZrtpControl#isSecurityVerified(String)
+     */
+    public void setReceivedSignaledZRTPHashValue(final String value) {
+        getTransformEngine().setReceivedSignaledZRTPHashValue(value);
+    }
 }

--- a/aTalk/src/main/java/org/atalk/service/neomedia/AbstractSrtpControl.java
+++ b/aTalk/src/main/java/org/atalk/service/neomedia/AbstractSrtpControl.java
@@ -104,9 +104,11 @@ public abstract class AbstractSrtpControl<T extends SrtpControl.TransformEngine>
 	 */
 	public T getTransformEngine()
 	{
-		if (transformEngine == null)
-			transformEngine = createTransformEngine();
-		return transformEngine;
+		synchronized (this) {
+			if (transformEngine == null)
+				transformEngine = createTransformEngine();
+			return transformEngine;
+		}
 	}
 
 	/**

--- a/aTalk/src/main/java/org/atalk/service/neomedia/ZrtpControl.java
+++ b/aTalk/src/main/java/org/atalk/service/neomedia/ZrtpControl.java
@@ -109,4 +109,16 @@ public interface ZrtpControl extends SrtpControl
      * @param verified the new SAS verification status
      */
     public void setSASVerification(boolean verified);
+
+    /**
+     * Set ZRTP version received from the signaling layer.
+     * @param version received version
+     */
+    public void setReceivedSignaledZRTPVersion(String version);
+
+    /**
+     * Set ZRTP hash value received from the signaling layer.
+     * @param value hash value
+     */
+    public void setReceivedSignaledZRTPHashValue(String value);
 }


### PR DESCRIPTION
<zrtp-hash/> element (as defined in XEP-0262) contains hash value of the
peer ZRTP Hello packet and the version of ZRTP protocol. With
setReceivedSignaledZRTPVersion, setReceivedSignaledZRTPHashValue
push the hash and version received from Jingle description down to
ZrtpControl and ZRTPTransformEngine.

Later, when the ZRTP Hello packet is received, the callback
ZRTPTransformEngine.sendInfo compares the hash value and version
of the ZRTP Hello packet with the hash value and version from Jingle
description.

fix race condition in AbstractSrtpControl.getTransformEngine

