### PR TITLE
Upgrade crypto algoritms used in ZRTP to stronger versions.

### DIFF
--- a/aTalk/src/main/java/org/atalk/impl/neomedia/transform/zrtp/ZrtpConfigureUtils.java
+++ b/aTalk/src/main/java/org/atalk/impl/neomedia/transform/zrtp/ZrtpConfigureUtils.java
@@ -21,11 +21,14 @@ public class ZrtpConfigureUtils
 	public static ZrtpConfigure getZrtpConfiguration()
 	{
 		ZrtpConfigure active = new ZrtpConfigure();
-		setupConfigure(ZrtpConstants.SupportedPubKeys.DH2K, active);
-		setupConfigure(ZrtpConstants.SupportedHashes.S256, active);
-		setupConfigure(ZrtpConstants.SupportedSymCiphers.AES1, active);
-		setupConfigure(ZrtpConstants.SupportedSASTypes.B32, active);
-		setupConfigure(ZrtpConstants.SupportedAuthLengths.HS32, active);
+
+		active.addAlgo(ZrtpConstants.SupportedHashes.S384);
+		active.addAlgo(ZrtpConstants.SupportedSymCiphers.AES3);
+		active.addAlgo(ZrtpConstants.SupportedSymCiphers.TWO3);
+		active.addAlgo(ZrtpConstants.SupportedPubKeys.E255);
+		active.addAlgo(ZrtpConstants.SupportedPubKeys.MULT);
+		active.addAlgo(ZrtpConstants.SupportedAuthLengths.HS80);
+		active.addAlgo(ZrtpConstants.SupportedAuthLengths.SK64);
 
 		return active;
 	}


### PR DESCRIPTION
Enable use of SHA-2 384

Prefer use of 256 bit ciphers AES-256 and TWOFISH-256
For technical details see paper:
Daniel J. Bernstein. "Understanding brute force."
ECRYPT STVL Workshop on Symmetric Key Encryption.
https://cr.yp.to/snuffle/bruteforce-20050425.pdf

Enable elliptic curve crypto using Curve 25519.
See the recommondations in paper
"Imperfect Forward Secrecy: How Diffie-Hellman Fails in Practice"
https://weakdh.org/imperfect-forward-secrecy-ccs15.pdf
https://cr.yp.to/newelliptic/nistecc-20160106.pdf

Use the longer HS80 and SK64 MACs.