### PR TITLE
Remove reference to org.atalk.impl.androidupdate.UpdateActivator

### DIFF
--- a/aTalk/src/main/assets/lib/osgi.client.run.properties
+++ b/aTalk/src/main/assets/lib/osgi.client.run.properties
@@ -59,7 +59,6 @@ auto.start.50= \
  org.atalk.android.plugin.certconfig.CertConfigActivator \
  org.atalk.impl.androidnotification.NotificationActivator \
  org.atalk.impl.androidtray.AndroidTrayActivator \
- org.atalk.impl.androidupdate.UpdateActivator \
  org.atalk.crypto.CryptoActivator \
  org.atalk.android.gui.chat.filetransfer.FileTransferActivator
 


### PR DESCRIPTION
The class org.atalk.impl.androidupdate.UpdateActivator
was deleted in 32e4e6e1