### PR TITLE
Use different ZID for the ZRTP connection with for each callee.

### DIFF
--- a/aTalk/src/main/java/net/java/sip/communicator/impl/protocol/jabber/CallJabberImpl.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/impl/protocol/jabber/CallJabberImpl.java
@@ -928,7 +928,7 @@ public class CallJabberImpl extends MediaAwareCall<CallPeerJabberImpl,
                 ProtocolProviderServiceJabberImpl.URN_XMPP_JINGLE_DTLS_SRTP)) {
             CallPeerMediaHandlerJabberImpl mediaHandler = peer.getMediaHandler();
             DtlsControl dtlsControl
-                    = (DtlsControl) mediaHandler.getSrtpControls().getOrCreate(mediaType, SrtpControlType.DTLS_SRTP);
+                    = (DtlsControl) mediaHandler.getSrtpControls().getOrCreate(mediaType, SrtpControlType.DTLS_SRTP, null);
 
             if (dtlsControl != null) {
                 IceUdpTransportExtensionElement transport = ensureTransportOnChannel(channel, peer);

--- a/aTalk/src/main/java/net/java/sip/communicator/impl/protocol/jabber/CallPeerMediaHandlerJabberImpl.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/impl/protocol/jabber/CallPeerMediaHandlerJabberImpl.java
@@ -20,6 +20,7 @@ import org.atalk.service.neomedia.device.MediaDevice;
 import org.atalk.service.neomedia.format.MediaFormat;
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smackx.disco.packet.DiscoverInfo;
+import org.jxmpp.jid.BareJid;
 import org.jxmpp.jid.Jid;
 import org.xmpp.extensions.colibri.ColibriConferenceIQ;
 import org.xmpp.extensions.colibri.SourceExtensionElement;
@@ -33,6 +34,8 @@ import java.util.*;
 
 import ch.imvs.sdes4j.srtp.SrtpCryptoAttribute;
 import timber.log.Timber;
+
+import static org.atalk.impl.neomedia.transform.zrtp.ZrtpControlImpl.generateMyZid;
 
 /**
  * An XMPP specific extension of the generic media handler.
@@ -1790,7 +1793,7 @@ public class CallPeerMediaHandlerJabberImpl extends CallPeerMediaHandler<CallPee
                         setup = DtlsControl.Setup.PASSIVE;
                     }
                     else {
-                        dtlsControl = (DtlsControl) srtpControls.getOrCreate(mediaType, SrtpControlType.DTLS_SRTP);
+                        dtlsControl = (DtlsControl) srtpControls.getOrCreate(mediaType, SrtpControlType.DTLS_SRTP, null);
                         setup = DtlsControl.Setup.ACTIVE;
                     }
                     if (dtlsControl != null) {
@@ -1897,7 +1900,7 @@ public class CallPeerMediaHandlerJabberImpl extends CallPeerMediaHandler<CallPee
                 addFingerprintToLocalTransport = addDtlsAdvertisedEncryptions(false, remoteContent, mediaType, false);
             }
             if (addFingerprintToLocalTransport) {
-                DtlsControl dtlsControl = (DtlsControl) srtpControls.getOrCreate(mediaType, SrtpControlType.DTLS_SRTP);
+                DtlsControl dtlsControl = (DtlsControl) srtpControls.getOrCreate(mediaType, SrtpControlType.DTLS_SRTP, null);
                 if (dtlsControl != null) {
                     DtlsControl.Setup setup = (remoteContent == null)
                             ? DtlsControl.Setup.PASSIVE : DtlsControl.Setup.ACTIVE;
@@ -2166,7 +2169,7 @@ public class CallPeerMediaHandlerJabberImpl extends CallPeerMediaHandler<CallPee
             if (accountID.getAccountPropertyBoolean(ProtocolProviderFactory.DEFAULT_ENCRYPTION, true)
                     && accountID.isEncryptionProtocolEnabled(SrtpControlType.SDES)) {
                 SrtpControls srtpControls = getSrtpControls();
-                SDesControl sdesControl = (SDesControl) srtpControls.getOrCreate(mediaType, SrtpControlType.SDES);
+                SDesControl sdesControl = (SDesControl) srtpControls.getOrCreate(mediaType, SrtpControlType.SDES, null);
                 SrtpCryptoAttribute selectedSdes
                         = selectSdesCryptoSuite(isInitiator, sdesControl, encryptionPacketExtension);
 
@@ -2268,7 +2271,8 @@ public class CallPeerMediaHandlerJabberImpl extends CallPeerMediaHandler<CallPee
             if (accountID.getAccountPropertyBoolean(ProtocolProviderFactory.DEFAULT_ENCRYPTION, true)
                     && accountID.isEncryptionProtocolEnabled(SrtpControlType.ZRTP)
                     && call.isSipZrtpAttribute()) {
-                ZrtpControl zrtpControl = (ZrtpControl) getSrtpControls().getOrCreate(mediaType, SrtpControlType.ZRTP);
+                final byte [] myZid = generateMyZid(peer.getPeerJid().asBareJid());
+                ZrtpControl zrtpControl = (ZrtpControl) getSrtpControls().getOrCreate(mediaType, SrtpControlType.ZRTP, myZid);
                 int numberSupportedVersions = zrtpControl.getNumberSupportedVersions();
 
                 // Try to get the remote ZRTP version and hash value
@@ -2336,7 +2340,7 @@ public class CallPeerMediaHandlerJabberImpl extends CallPeerMediaHandler<CallPee
                 && accountID.isEncryptionProtocolEnabled(SrtpControlType.SDES)) {
             // get or create the control
             SrtpControls srtpControls = getSrtpControls();
-            SDesControl sdesControl = (SDesControl) srtpControls.getOrCreate(mediaType, SrtpControlType.SDES);
+            SDesControl sdesControl = (SDesControl) srtpControls.getOrCreate(mediaType, SrtpControlType.SDES, null);
             // set the enabled ciphers suites
             String ciphers = accountID.getAccountPropertyString(ProtocolProviderFactory.SDES_CIPHER_SUITES);
 

--- a/aTalk/src/main/java/net/java/sip/communicator/service/protocol/media/SrtpControls.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/service/protocol/media/SrtpControls.java
@@ -52,14 +52,14 @@ public class SrtpControls
 		return elements[mediaType.ordinal()][srtpControlType.ordinal()];
 	}
 
-	public SrtpControl getOrCreate(MediaType mediaType, SrtpControlType srtpControlType)
+	public SrtpControl getOrCreate(MediaType mediaType, SrtpControlType srtpControlType, final byte [] myZid)
 	{
 		SrtpControl[] elements = this.elements[mediaType.ordinal()];
 		int index = srtpControlType.ordinal();
 		SrtpControl element = elements[index];
 
 		if (element == null) {
-			element = ProtocolMediaActivator.getMediaService().createSrtpControl(srtpControlType);
+			element = ProtocolMediaActivator.getMediaService().createSrtpControl(srtpControlType, myZid);
 			if (element != null)
 				elements[index] = element;
 		}

--- a/aTalk/src/main/java/net/java/sip/communicator/util/ConfigurationUtils.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/util/ConfigurationUtils.java
@@ -43,6 +43,8 @@ import org.osgi.framework.ServiceReference;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
+import java.math.BigInteger;
+import java.security.SecureRandom;
 import java.util.*;
 
 import javax.net.ssl.SSLSocket;
@@ -476,6 +478,16 @@ public class ConfigurationUtils
      * Indicates if window (task bar or dock icon) alerter is enabled.
      */
     private static boolean alerterEnabled;
+
+    /**
+     * Instalation unique salt. Used for ZID computation
+     */
+    private static String installationUniqueSalt;
+
+    /**
+     * Instalation unique salt property name.
+     */
+    private static final String pInstallationUniqueSalt = "INSTALLATION_UNIQUE_SALT";
 
     private static SQLiteDatabase mDB;
     private static ContentValues contentValues = new ContentValues();
@@ -2677,5 +2689,27 @@ public class ConfigurationUtils
                 }
             }
         }
+    }
+
+    public static String getInstallationUniqueSalt() {
+        if (installationUniqueSalt != null)
+        {
+            return installationUniqueSalt;
+        }
+
+        installationUniqueSalt = configService.getString(pInstallationUniqueSalt);
+
+        if (installationUniqueSalt == null)
+        {
+            installationUniqueSalt = new BigInteger(256, new SecureRandom()).toString(32);
+            configService.setProperty(pInstallationUniqueSalt, installationUniqueSalt);
+        }
+
+        return installationUniqueSalt;
+    }
+
+    public static void resetInstallationUniqueSalt() {
+        configService.removeProperty(pInstallationUniqueSalt);
+        installationUniqueSalt = null;
     }
 }

--- a/aTalk/src/main/java/org/atalk/android/gui/settings/SettingsActivity.java
+++ b/aTalk/src/main/java/org/atalk/android/gui/settings/SettingsActivity.java
@@ -11,6 +11,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.*;
 import android.text.TextUtils;
+import android.widget.Toast;
 
 import net.java.sip.communicator.service.msghistory.MessageHistoryService;
 import net.java.sip.communicator.service.systray.PopupMessageHandler;
@@ -120,6 +121,9 @@ public class SettingsActivity extends OSGiActivity
     // User option property names
     public static final String AUTO_UPDATE_CHECK_ENABLE = "user.AUTO_UPDATE_CHECK_ENABLE";
 
+    // Reset ZID
+    public static final String P_KEY_RESET_ZID = aTalkApp.getResString(R.string.pref_key_zid_reset);
+
     /**
      * {@inheritDoc}
      */
@@ -204,6 +208,8 @@ public class SettingsActivity extends OSGiActivity
             else {
                 disableMediaOptions();
             }
+
+            initResetZID();
 
             SharedPreferences shPrefs = getPreferenceManager().getSharedPreferences();
             shPrefs.registerOnSharedPreferenceChangeListener(this);
@@ -843,6 +849,16 @@ public class SettingsActivity extends OSGiActivity
                 deviceConfig.setVideoBitrate(bitrate);
                 ((EditTextPreference) findPreference(P_KEY_VIDEO_BITRATE)).setText(Integer.toString(bitrate));
             }
+        }
+
+        private void initResetZID() {
+            findPreference(P_KEY_RESET_ZID).setOnPreferenceClickListener(
+                    preference -> {
+                        ConfigurationUtils.resetInstallationUniqueSalt();
+                        Toast.makeText(getActivity(), R.string.ZID_has_been_reset_toast, Toast.LENGTH_SHORT).show();
+                        return true;
+                    }
+            );
         }
     }
 }

--- a/aTalk/src/main/java/org/atalk/impl/neomedia/MediaServiceImpl.java
+++ b/aTalk/src/main/java/org/atalk/impl/neomedia/MediaServiceImpl.java
@@ -618,7 +618,7 @@ public class MediaServiceImpl extends PropertyChangeNotifier implements MediaSer
     /**
      * {@inheritDoc}
      */
-    public SrtpControl createSrtpControl(SrtpControlType srtpControlType)
+    public SrtpControl createSrtpControl(SrtpControlType srtpControlType, final byte[] myZid)
     {
         switch (srtpControlType) {
             case DTLS_SRTP:
@@ -626,7 +626,7 @@ public class MediaServiceImpl extends PropertyChangeNotifier implements MediaSer
             case SDES:
                 return new SDesControlImpl();
             case ZRTP:
-                return new ZrtpControlImpl();
+                return new ZrtpControlImpl(myZid);
             default:
                 return null;
         }

--- a/aTalk/src/main/java/org/atalk/impl/neomedia/MediaStreamImpl.java
+++ b/aTalk/src/main/java/org/atalk/impl/neomedia/MediaStreamImpl.java
@@ -337,7 +337,7 @@ public class MediaStreamImpl extends AbstractMediaStream
         // If you change the default behavior (initiates a ZrtpControlImpl if the srtpControl
         // attribute is null), please accordingly modify the CallPeerMediaHandler.initStream function.
         this.srtpControl = (srtpControl == null)
-                ? NeomediaServiceUtils.getMediaServiceImpl().createSrtpControl(SrtpControlType.ZRTP) : srtpControl;
+                ? NeomediaServiceUtils.getMediaServiceImpl().createSrtpControl(SrtpControlType.ZRTP, null) : srtpControl;
 
         this.srtpControl.registerUser(this);
 

--- a/aTalk/src/main/java/org/atalk/service/neomedia/MediaService.java
+++ b/aTalk/src/main/java/org/atalk/service/neomedia/MediaService.java
@@ -224,7 +224,7 @@ public interface MediaService
 	 *        the <tt>SrtpControlType</tt> of the new instance
 	 * @return a new <tt>SrtpControl</tt> instance with the specified <tt>srtpControlType</tt>
 	 */
-	public SrtpControl createSrtpControl(SrtpControlType srtpControlType);
+	public SrtpControl createSrtpControl(SrtpControlType srtpControlType, final byte [] myZid);
 
 	/**
 	 * Get available <tt>ScreenDevice</tt>s.

--- a/aTalk/src/main/res/values/strings.xml
+++ b/aTalk/src/main/res/values/strings.xml
@@ -1120,6 +1120,12 @@
     <string name="service_gui_TLS_CERT_PROMPT">Please select TLS certificate</string>
     <string name="service_gui_TLS_CERT_SUMMARY">Certificate use in user authentication with server</string>
 
+    <!-- Reset ZID -->
+    <string name="pref_key_zid_reset">pref.key.zid.reset</string>
+    <string name="reset_ZID_summary">Reset long-lived ZRTP identifier</string>
+    <string name="reset_ZID_title">Reset ZID</string>
+    <string name="ZID_has_been_reset_toast">ZID has been reset</string>
+
     <!-- Settings -->
     <string name="service_gui_COMMIT_PROGRESS_MSG">Storing account changes, please wait&#8230;</string>
     <string name="service_gui_COMMIT_PROGRESS_TITLE">"Committing&#8230;"</string>

--- a/aTalk/src/main/res/xml/preferences.xml
+++ b/aTalk/src/main/res/xml/preferences.xml
@@ -70,6 +70,13 @@
             <intent android:action=".impl.androidcertdialog.ConnectionInfo" />
         </PreferenceScreen>
 
+        <!-- Reset ZID -->
+        <PreferenceScreen
+            android:key="@string/pref_key_zid_reset"
+            android:summary="@string/reset_ZID_summary"
+            android:title="@string/reset_ZID_title">
+            <!--<intent android:action=".impl.reset_ZID" />-->
+        </PreferenceScreen>
     </PreferenceCategory>
 
     <!-- Message settings -->


### PR DESCRIPTION
Make fingerprinting of ZRTP connections harder by using a different ZID for
each callee. Client ZID is calculated using a hash of the value
INSTALLATION_UNIQUE_SALT and peer JID if the callee. (Only the bare JID part
can be used, and not the full JID, because peers can generate new resource
at each application start and this would can a new ZID at each application
start and this would break the purpouse of the SAS checking).

INSTALLATION_UNIQUE_SALT value is stored in properties and the user can choose
to generate a new salt value from UI.

Implementation details:

- ZID calculation is done in generateMyZid

- For the receiving calls the creation of the ZrtpControlImpl instance had
  to be moved to MediaHandler.initStream because only here the information
  about peer Jid was present.

- These methods are not used and have been removed:

public boolean ZRTPTransformEngine.initialize(String zidFilename, boolean autoEnable)
public boolean ZRTPTransformEngine.initialize(String zidFilename)

Fixes issue #122