### PR TITLE
When adding a new contact pre-approve subscription for it

### DIFF
--- a/aTalk/src/main/java/net/java/sip/communicator/impl/protocol/jabber/ServerStoredContactListJabberImpl.java
+++ b/aTalk/src/main/java/net/java/sip/communicator/impl/protocol/jabber/ServerStoredContactListJabberImpl.java
@@ -38,6 +38,7 @@ import net.java.sip.communicator.service.protocol.event.SubscriptionEvent;
 
 import org.atalk.impl.timberlog.TimberLog;
 import org.atalk.persistance.DatabaseBackend;
+import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.SmackException.NoResponseException;
 import org.jivesoftware.smack.SmackException.NotConnectedException;
 import org.jivesoftware.smack.SmackException.NotLoggedInException;
@@ -508,7 +509,7 @@ public class ServerStoredContactListJabberImpl {
          * update the roster with the subscription status.
          */
         try {
-            mRoster.createItemAndRequestSubscription(contactJid, contactJid.toString(), parentNames);
+            addContactToRoster(contactJid, contactJid.toString(), parentNames);
         } catch (XMPPErrorException ex) {
             String errTxt = "Error adding new jabber roster entry";
             Timber.e(ex, "%s", errTxt);
@@ -529,6 +530,17 @@ public class ServerStoredContactListJabberImpl {
             throw new OperationFailedException(errTxt, errorCode, ex);
         } catch (NotLoggedInException | NoResponseException | NotConnectedException | InterruptedException ex) {
             Timber.w("addContact: %s", ex.getMessage());
+        }
+    }
+
+    private void addContactToRoster(BareJid contactJid, String displayName, String[] parentNames) throws NotLoggedInException, NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException {
+        if (mRoster.isSubscriptionPreApprovalSupported()) {
+            try {
+                mRoster.preApproveAndCreateEntry(contactJid, displayName, parentNames);
+            } catch (SmackException.FeatureNotSupportedException ignored) {}
+        }
+        else {
+            mRoster.createItemAndRequestSubscription(contactJid, displayName, parentNames);
         }
     }
 
@@ -786,7 +798,7 @@ public class ServerStoredContactListJabberImpl {
         xmppConnection.setReplyTimeout(ProtocolProviderServiceJabberImpl.SMACK_REPLY_EXTENDED_TIMEOUT_30);
         try {
             // Do not use getSourceEntry() to getJid(); may be null if contact is not in roster.
-            mRoster.createItemAndRequestSubscription(contact.getJid().asBareJid(), contact.getDisplayName(),
+            addContactToRoster(contact.getJid().asBareJid(), contact.getDisplayName(),
                     new String[]{newParent.getGroupName()});
             newParent.addContact(contact);
         } catch (XMPPException ex) {


### PR DESCRIPTION
When you add a contact it receives a notification about a subscription request.
Once he approve it you can see his presence status (online or not).
Be he also needs to see your status so he sends its own subscription request to you. The aTalk automatically accepts such subscription requests (see `net/java/sip/communicator/impl/protocol/jabber/OperationSetPersistentPresenceJabberImpl.java:1529`). It checks if the contact is your roster.
The problem is that if you received a subscription request not the aTalk but in other IM client (Pidgin) then you'll have to approve it manually even while you already totally fine with this.

The XMPP has a pre-approval so when you add a contact you can before-ahead approve a subscription request to you for him.
 
